### PR TITLE
Changed docstring to conform to return type

### DIFF
--- a/edx_api/certificates/__init__.py
+++ b/edx_api/certificates/__init__.py
@@ -50,14 +50,14 @@ class UserCertificates(object):
 
     def get_student_certificates(self, username, course_ids=None):
         """
-        Returns an Certificate object with the user certificates
+        Returns an Certificates object with the user certificates
 
         Args:
             username (str): an edx user's username
             course_ids (list): a list of edX course ids.
 
         Returns:
-            Certificate: object representing the student certificate for a course
+            Certificates: object representing the student certificates for a course
         """
         # if no course ids are provided, let's get the user enrollments
         if course_ids is None:


### PR DESCRIPTION
#### What's this PR do?
Fixes the return value in a docstring to match the returned type, so PyCharm doesn't get confused
