### PR TITLE
Changed certificates function to raise HTTPError

### DIFF
--- a/edx_api/certificates/__init__.py
+++ b/edx_api/certificates/__init__.py
@@ -69,7 +69,8 @@ class UserCertificates(object):
         for course_id in course_ids:
             try:
                 all_certificates.append(self.get_student_certificate(username, course_id))
-            except HTTPError:
-                pass
+            except HTTPError as error:
+                if error.response.status_code >= 500:
+                    raise
 
         return Certificates(all_certificates)

--- a/edx_api/integration_test.py
+++ b/edx_api/integration_test.py
@@ -1,11 +1,11 @@
 """
 Integration tests.
 
-Thes run against actual edx apis.
+These run against actual edX APIs.
 
 NOTE: To run this test you need a running instance of edX properly configured.
 This means that you need:
-- the edx demo course
+- the edx demo course set to course mode 'audit' (the default)
 - the user staff being "staff" of such course
 - the course being open to enrollment
 - the course having the ccx enabled in the advanced settings
@@ -30,7 +30,10 @@ GeneratedCertificateFactory.create(
 """
 import os
 
+from mock import patch
 import pytest
+from requests.exceptions import HTTPError
+from requests import Response
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 
 from .client import EdxApi
@@ -143,3 +146,85 @@ def test_get_certificate():
     assert len(certificates.all_courses_certs) >= 1
     assert 'course-v1:edX+DemoX+Demo_Course' in certificates.all_courses_certs
     assert 'course-v1:edX+DemoX+Demo_Course' in certificates.all_courses_verified_certs
+
+
+class FakeErroredResponse(object):
+    """Fake requests response"""
+    def __init__(self, status_code):
+        """
+        Build a fake error response
+        """
+        self.error = HTTPError(response=Response())
+        self.error.response = Response()
+        self.error.response.status_code = status_code
+
+    def raise_for_status(self):
+        """Raise an HTTPError"""
+        raise self.error
+
+
+@require_integration_settings
+def test_get_certificate_500_error():
+    """
+    Asserts that a 500 error returned from EDX will be propagated
+    """
+
+    api = EdxApi({'access_token': ACCESS_TOKEN}, base_url=BASE_URL)
+    username = 'staff'
+    course_key = 'course-v1:edX+DemoX+Demo_Course'
+
+    certificates = api.certificates
+    old_requester_get = certificates.requester.get
+
+    def mocked_get(url, *args, **kwargs):
+        """
+        Return an error for specific URLs
+        """
+        if '/api/certificates/v0/certificates/' in url:
+            return FakeErroredResponse(status_code=500)
+        else:
+            return old_requester_get(url, *args, **kwargs)
+
+    with patch.object(certificates.requester, 'get', autospec=True) as get:
+        get.side_effect = mocked_get
+        with pytest.raises(HTTPError):
+            certificates.get_student_certificate(
+                username, course_key
+            )
+
+        with pytest.raises(HTTPError):
+            certificates.get_student_certificates(username)
+
+
+@require_integration_settings
+def test_get_certificate_404_error():
+    """
+    Asserts that a 404 returned from EDX will be silenced for get_student_certificates
+    """
+
+    api = EdxApi({'access_token': ACCESS_TOKEN}, base_url=BASE_URL)
+    username = 'staff'
+    course_key = 'course-v1:edX+DemoX+Demo_Course'
+
+    certificates = api.certificates
+    old_requester_get = certificates.requester.get
+
+    def mocked_get(url, *args, **kwargs):
+        """
+        Return an error for specific URLs
+        """
+        if '/api/certificates/v0/certificates/' in url:
+            return FakeErroredResponse(status_code=404)
+        else:
+            return old_requester_get(url, *args, **kwargs)
+
+    with patch.object(certificates.requester, 'get', autospec=True) as get:
+        get.side_effect = mocked_get
+        with pytest.raises(HTTPError):
+            certificates.get_student_certificate(
+                username, course_key
+            )
+
+        # Note no error here, just empty list
+        certs = certificates.get_student_certificates(username)
+        assert len(certs.all_courses_certs) == 0


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #18

#### What's this PR do?
Removes the code to silence HTTPErrors. @giocalitri can you comment on if this is needed for something? 

#### How should this be manually tested?
This should fix https://github.com/mitodl/micromasters/issues/589 so you can go through the steps to reproduce this but with the updated edx-api-client.
