### PR TITLE
Added capability to create enrollment in a course

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Python interface for edX REST APIs
 To get the latest stable release from PyPi
 
 ```bash
-pip install edx-api-client (not yet deployed on pypi)
+pip install edx-api-client
 ```
 
 To get the latest commit from GitHub
@@ -35,3 +35,4 @@ must be enabled for CCX.
 
 ## Release Notes
 
+See the RELEASE.rst file

--- a/edx_api/enrollments/__init__.py
+++ b/edx_api/enrollments/__init__.py
@@ -3,7 +3,7 @@ edX Enrollment REST API client class
 """
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 
-from .models import Enrollments
+from .models import Enrollment, Enrollments
 
 
 # pylint: disable=too-few-public-methods
@@ -11,6 +11,8 @@ class CourseEnrollments(object):
     """
     edX student enrollments client
     """
+
+    enrollment_url = '/api/enrollment/v1/enrollment'
 
     def __init__(self, requester, base_url):
         """
@@ -30,8 +32,28 @@ class CourseEnrollments(object):
         """
         # the request is done in behalf of the current logged in user
         resp = self.requester.get(
-            urljoin(self.base_url, '/api/enrollment/v1/enrollment'))
-
+            urljoin(self.base_url, self.enrollment_url))
         resp.raise_for_status()
-
         return Enrollments(resp.json())
+
+    def create_audit_student_enrollment(self, course_id):
+        """
+        Creates an audit enrollment for the user in a given course
+
+        Args:
+            course_id (str): an edX course id
+
+        Returns:
+            Enrollment: object representing the student enrollment in the provided course
+        """
+        audit_enrollment = {
+            "mode": "audit",
+            "course_details": {"course_id": course_id}
+        }
+        # the request is done in behalf of the current logged in user
+        resp = self.requester.post(
+            urljoin(self.base_url, self.enrollment_url),
+            json=audit_enrollment
+        )
+        resp.raise_for_status()
+        return Enrollment(resp.json())

--- a/edx_api/enrollments/init_test.py
+++ b/edx_api/enrollments/init_test.py
@@ -1,0 +1,42 @@
+"""
+Tests for the content of the __init__ module
+"""
+import json
+import os
+from unittest import TestCase
+
+import requests_mock
+from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
+
+from edx_api.client import EdxApi
+from edx_api.enrollments import CourseEnrollments
+
+
+class EnrollmentsTest(TestCase):
+    """
+    Tests for the enrollments base function in the __init__ module
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        with open(os.path.join(os.path.dirname(__file__),
+                               'fixtures/user_enrollments.json')) as file_obj:
+            cls.enrollments_json = json.loads(file_obj.read())
+
+        cls.enrollment_json = cls.enrollments_json[0]
+        base_edx_url = 'http://edx.example.com'
+        cls.base_url = urljoin(base_edx_url, CourseEnrollments.enrollment_url)
+        client = EdxApi({'access_token': 'foobar'}, cls.base_url)
+        cls.enrollment_client = client.enrollments
+
+    @requests_mock.mock()
+    def test_create_enrollment(self, mock_req):
+        """
+        Tests the post request to create an enrollment.
+        This just tests that the client expects a JSON object representing the enrollment.
+        """
+        mock_req.post(self.base_url, text=json.dumps(self.enrollment_json))
+        enrollment = self.enrollment_client.create_audit_student_enrollment(
+            self.enrollment_json['course_details']['course_id'])
+        for key, val in enrollment.json.items():
+            assert self.enrollment_json.get(key) == val

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python-dateutil==2.5.3
-requests==2.10.0
+requests==2.11.1
 six==1.10.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -11,4 +11,4 @@ pytest-pylint
 pytest-cov
 ipython
 wheel
-
+requests-mock


### PR DESCRIPTION
#### What are the relevant tickets?
closes #26 

#### What's this PR do?
Introduces the support for creating an audit enrollment in a specified course

#### Where should the reviewer start?
`edx_api/enrollments/__init__.py`

#### How should this be manually tested?
try to enrolls the user is a course or just run the integration tests

#### Any background context you want to provide?
Currently one of the integration tests (the ccx one) fails due to a problem about the edx support of OAUTH in the ccx 

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
