### PR TITLE
Don't silence HTTP errors in grades

### DIFF
--- a/edx_api/grades/__init__.py
+++ b/edx_api/grades/__init__.py
@@ -67,10 +67,6 @@ class UserCurrentGrades(object):
 
         all_current_grades = []
         for course_id in course_ids:
-            try:
-                all_current_grades.append(self.get_student_current_grade(username, course_id))
-            except HTTPError as error:
-                if error.response.status_code >= 500:
-                    raise
+            all_current_grades.append(self.get_student_current_grade(username, course_id))
 
         return CurrentGrades(all_current_grades)


### PR DESCRIPTION
#### What are the relevant tickets?
Related to issue in MM#2657
#### What's this PR do?
Removes silencing of HTTP errors, so that we can count users for which update cache failed.
