### PR TITLE
Query grades by course

### DIFF
--- a/edx_api/grades/fixtures/course_grades_hawthorn.json
+++ b/edx_api/grades/fixtures/course_grades_hawthorn.json
@@ -1,18 +1,18 @@
 [
 	{
 		"course_id": "course-v1:edX+DemoX+Demo_Course",
-		"email": "bob@example.com",
+		"email": "tomoko@example.com",
 		"passed": true,
 		"percent": 0.97,
 		"letter_grade": "Pass",
-		"username": "bob"
+		"username": "tomoko"
 	},
 	{
-		"course_id": "course-v1:MITx+8.MechCX+2014_T1",
-		"email": "bob@example.com",
+		"course_id": "course-v1:edX+DemoX+Demo_Course",
+		"email": "amir@example.com",
 		"passed": false,
 		"percent": 0.03,
 		"letter_grade": null,
-		"username": "bob"
+		"username": "amir"
 	}
 ]

--- a/edx_api/grades/fixtures/course_grades_ironwood_p1.json
+++ b/edx_api/grades/fixtures/course_grades_ironwood_p1.json
@@ -1,0 +1,22 @@
+{
+	"next": "https://edx.example.com/api/v1/grades/?page=2",
+	"previous": null,
+	"results": [
+		{
+			"course_id": "course-v1:edX+DemoX+Demo_Course",
+			"email": "tomoko@example.com",
+			"passed": true,
+			"percent": 0.97,
+			"letter_grade": "Pass",
+			"username": "tomoko"
+		},
+		{
+			"course_id": "course-v1:edX+DemoX+Demo_Course",
+			"email": "amir@example.com",
+			"passed": false,
+			"percent": 0.03,
+			"letter_grade": null,
+			"username": "amir"
+		}
+	]
+}

--- a/edx_api/grades/fixtures/course_grades_ironwood_p2.json
+++ b/edx_api/grades/fixtures/course_grades_ironwood_p2.json
@@ -1,0 +1,22 @@
+{
+	"next": null,
+	"previous": "https://edx.example.com/api/v1/grades/?page=1",
+	"results": [
+		{
+			"course_id": "course-v1:edX+DemoX+Demo_Course",
+			"email": "wayne@example.com",
+			"passed": true,
+			"percent": 0.97,
+			"letter_grade": "Pass",
+			"username": "wayne"
+		},
+		{
+			"course_id": "course-v1:edX+DemoX+Demo_Course",
+			"email": "sefiri@example.com",
+			"passed": false,
+			"percent": 0.03,
+			"letter_grade": null,
+			"username": "sefiri"
+		}
+	]
+}

--- a/edx_api/grades/init_test.py
+++ b/edx_api/grades/init_test.py
@@ -1,0 +1,104 @@
+"""
+Test handling of responses from grades api.
+"""
+
+import json
+import os
+from unittest import TestCase
+
+import requests_mock
+import six
+
+from edx_api import enrollments, grades
+from edx_api.client import EdxApi
+
+
+class GradesApiTestCase(TestCase):
+    """
+    Test handling of mocked API responses in Grades API client.
+    """
+
+    base_url = "https://edx.example.com"
+
+    def setUp(self):
+        super(GradesApiTestCase, self).setUp()
+
+        with open(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../enrollments/fixtures/user_enrollments.json",
+            )
+        ) as file:  # pylint: disable=redefined-builtin
+            self.enrollment_data = json.load(file)
+        self.enrollment_url = six.moves.urllib.parse.urljoin(
+            "https://edx.example.com", enrollments.CourseEnrollments.enrollment_url
+        )
+        self.client = EdxApi({"access_token": "opensesame"}, "https://edx.example.com")
+
+    @requests_mock.mock()
+    def test_api_return_value(self, mock_req):
+        """
+        Verify that the object returned from the current_grades endpoints is a CurrentGrades.
+        """
+        mock_req.get(
+            requests_mock.ANY,
+            text=json.dumps(self.get_grades_data("course_grades_hawthorn.json")),
+        )
+        mock_req.get(self.enrollment_url, text=json.dumps(self.enrollment_data))
+        response = self.client.current_grades.get_course_current_grades(
+            "course-v1:edX+DemoX+Demo_Course"
+        )
+        assert isinstance(response, grades.CurrentGradesByCourse)
+
+    @requests_mock.mock()
+    def test_ironwood_api(self, mock_req):
+        """
+        Verify that the api can handle the ironwood version of the api.
+        """
+        mock_req.get(
+            requests_mock.ANY,
+            text=json.dumps(self.get_grades_data("course_grades_ironwood_p2.json")),
+        )
+        mock_req.get(self.enrollment_url, text=json.dumps(self.enrollment_data))
+        grades_response = self.client.current_grades.get_course_current_grades(
+            "course-v1:edX+DemoX+Demo_Course"
+        )
+        assert isinstance(grades_response, grades.CurrentGradesByCourse)
+        self.assertEqual(len(grades_response.current_grades), 2)
+
+    @requests_mock.mock()
+    def test_paginated_ironwood_api(self, mock_req):
+        """
+        Verify that the ironwood api handles paginated data properly
+        """
+        mock_req.get(
+            requests_mock.ANY,
+            [
+                {
+                    "text": json.dumps(
+                        self.get_grades_data("course_grades_ironwood_p1.json")
+                    )
+                },
+                {
+                    "text": json.dumps(
+                        self.get_grades_data("course_grades_ironwood_p2.json")
+                    )
+                },
+            ],
+        )
+        mock_req.get(self.enrollment_url, text=json.dumps(self.enrollment_data))
+        grades_response = self.client.current_grades.get_course_current_grades(
+            "course-v1:edX+DemoX+Demo_Course"
+        )
+        self.assertIsInstance(grades_response, grades.CurrentGradesByCourse)
+        self.assertEqual(len(grades_response.current_grades), 4)
+
+    @staticmethod
+    def get_grades_data(filename):
+        """
+        Return the JSON data from the named fixture.
+        """
+        with open(
+            os.path.join(os.path.dirname(__file__), "fixtures", filename)
+        ) as file:  # pylint: disable=redefined-builtin
+            return json.load(file)

--- a/edx_api/grades/models.py
+++ b/edx_api/grades/models.py
@@ -1,23 +1,79 @@
 """
 Business objects for the Grades API
 """
-from collections import Iterable
 
-from six import python_2_unicode_compatible
+from __future__ import unicode_literals
+from six import PY2, python_2_unicode_compatible
 
+# pylint: disable=no-name-in-module, import-error
+if PY2:
+    from collections import Iterable
+else:
+    from collections.abc import Iterable
+# pylint: enable=no-name-in-module, import-error
 # pylint: disable=too-few-public-methods
 
 
-@python_2_unicode_compatible
 class CurrentGrades(object):
     """
     Current Grades object representation
     """
     def __init__(self, current_grade_list):
         if not isinstance(current_grade_list, Iterable):
-            raise TypeError('CurrentGrades needs a Iterable object')
+            raise TypeError('CurrentGrades needs an Iterable object')
+
+    @property
+    def all_current_grades(self):
+        """Helper property to return all the CurrentGrade objects"""
+        return self.current_grades.values()  # pylint: disable=no-member
+
+
+@python_2_unicode_compatible
+class CurrentGradesByCourse(CurrentGrades):
+    """
+    Represents the current grades for a specific course
+    """
+    def __init__(self, current_grade_list):
+        """
+        Args:
+            current_grade_list (list): A list of the CurrentGrade objects
+        """
+        super(CurrentGradesByCourse, self).__init__(current_grade_list)
+        self.course_id = None
         self.current_grades = {}
+        for current_grade in current_grade_list:
+            if not isinstance(current_grade, CurrentGrade):
+                raise ValueError("Only CurrentGrade objects are allowed")
+            if self.course_id is None:
+                self.course_id = current_grade.course_id
+            if self.course_id is not None and current_grade.course_id != self.course_id:
+                raise ValueError("Only CurrentGrade objects for the same course are allowed")
+            self.current_grades[current_grade.username] = current_grade
+
+    def __str__(self):
+        return "<Current Grades for course {course_id}>".format(
+            course_id=self.course_id
+        )
+
+    @property
+    def all_usernames(self):
+        """Helper property to return all the usernames of the current grades"""
+        return self.current_grades.keys()
+
+
+@python_2_unicode_compatible
+class CurrentGradesByUser(CurrentGrades):
+    """
+    Represents the current grades for a specific user
+    """
+    def __init__(self, current_grade_list):
+        """
+        Args:
+            current_grade_list (list): A list of the CurrentGrade objects
+        """
+        super(CurrentGradesByUser, self).__init__(current_grade_list)
         self.username = None
+        self.current_grades = {}
         for current_grade in current_grade_list:
             if not isinstance(current_grade, CurrentGrade):
                 raise ValueError("Only CurrentGrade objects are allowed")
@@ -28,17 +84,14 @@ class CurrentGrades(object):
             self.current_grades[current_grade.course_id] = current_grade
 
     def __str__(self):
-        return "<Current Grades for user {username}>".format(username=self.username)
+        return "<Current Grades for user {username}>".format(
+            username=self.username
+        )
 
     @property
     def all_course_ids(self):
         """Helper property to return all the course ids of the current grades"""
         return self.current_grades.keys()
-
-    @property
-    def all_current_grades(self):
-        """Helper property to return all the current grade objects"""
-        return self.current_grades.values()
 
     def get_current_grade(self, course_id):
         """Returns the current grade for the given course id"""

--- a/edx_api/integration_test.py
+++ b/edx_api/integration_test.py
@@ -353,9 +353,13 @@ def test_get_current_grade():
         'staff', 'course-v1:edX+DemoX+Demo_Course')
     assert course_grade.username == 'staff'
 
-    course_grades = api.current_grades.get_student_current_grades('staff')
-    assert len(course_grades.all_course_ids) >= 1
-    assert 'course-v1:edX+DemoX+Demo_Course' in course_grades.all_course_ids
+    student_grades = api.current_grades.get_student_current_grades('staff')
+    assert len(student_grades.all_course_ids) >= 1
+    assert 'course-v1:edX+DemoX+Demo_Course' in student_grades.all_course_ids
+
+    course_grades = api.current_grades.get_course_current_grades('course-v1:edX+DemoX+Demo_Course')
+    assert len(course_grades.all_usernames) >= 1
+    assert 'honor' in course_grades.all_usernames
 
 
 @require_integration_settings


### PR DESCRIPTION
@kaizoku, @pdpinch 

#### What are the relevant tickets?  

* BB-1098
* fixes https://github.com/mitodl/edx-api-client/issues/41

#### What's this PR do?  

Add the ability for staff to query the edx grade api for the grades of all users in a given course.

#### Where should the reviewer start?

?

#### How should this be manually tested?

Call the api, and verify that the appropriate results are returned from the API.

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

![Manufacturing pretzels](https://twistedsifter.files.wordpress.com/2014/01/how-pretzels-are-tied-gif.gif)
