### PR TITLE
BB-1097 Implement batch enrollments query.

### DIFF
--- a/edx_api/enrollments/__init__.py
+++ b/edx_api/enrollments/__init__.py
@@ -1,6 +1,10 @@
 """
 edX Enrollment REST API client class
 """
+try:
+    from urlparse import urlparse, parse_qs
+except ImportError:
+    from urllib.parse import urlparse, parse_qs
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 
 from .models import Enrollment, Enrollments
@@ -13,6 +17,7 @@ class CourseEnrollments(object):
     """
 
     enrollment_url = '/api/enrollment/v1/enrollment'
+    enrollment_list_url = '/api/enrollment/v1/enrollments'
 
     def __init__(self, requester, base_url):
         """
@@ -22,6 +27,83 @@ class CourseEnrollments(object):
         """
         self.requester = requester
         self.base_url = base_url
+
+    def _get_enrollments_list_page(self, params=None):
+        """
+        Submit request to retrieve enrollments list.
+
+        Args:
+            params (dict): Query parameters to use in the request. Valid parameters are:
+                * course_id: Filters the result to course enrollments for the course
+                    corresponding to the given course ID. The value must be URL encoded.
+                    Optional.
+                * username: username: List of comma-separated usernames. Filters the result to the
+                    course enrollments of the given users. Optional.
+        """
+        req_url = urljoin(self.base_url, self.enrollment_list_url)
+        resp = self.requester.get(req_url, params=params)
+        resp.raise_for_status()
+        resp_json = resp.json()
+        results = resp_json['results']
+        next_url_str = resp_json.get('next')
+        cursor = None
+        qstr_cursor = None
+        if next_url_str:
+            next_url = urlparse(next_url_str)
+            qstr = parse_qs(next_url.query)
+            qstr_cursor = qstr.get('cursor')
+
+        if qstr_cursor and isinstance(qstr_cursor, list):
+            cursor = qstr_cursor[0]
+
+        return results, cursor
+
+    def get_enrollments(self, course_id=None, usernames=None):
+        """
+        List all course enrollments.
+
+        Args:
+            course_id (str, optional): If used enrollments will be filtered to the specified
+                course id.
+            usernames (list, optional): List of usernames to filter enrollments.
+
+        Notes:
+            - This method returns an iterator to avoid going through the entire pagination at once.
+            - The :class:`Enrollments` instance returned for each generated item will not have any
+                course details.
+
+        Examples:
+            Get all enrollments for a specific course id
+            >>> api = EdxApi({'access_token': 'token'}, 'http://base_url')
+            >>> enrollments = api.enrollments.get_enrollments(course_id='course_id')
+            >>> for enrollment in enrollments:
+                    do_something(enrollment)
+
+            Get all enrollments for a set of usernames
+            >>> api = EdxApi({'access_token': 'token'}, 'http://base_url')
+            >>> enrollments = api.enrollments.get_enrollments(usernames=['user1', 'user2'])
+            >>> for enrollment in enrollments:
+                    do_something(enrollment)
+
+        Returns:
+            Generator with an instance of :class:`Enrollments` for each item.
+        """
+        params = {}
+        if course_id is not None:
+            params['course_id'] = course_id
+        if usernames is not None and isinstance(usernames, list):
+            params['username'] = ','.join(usernames)
+
+        done = False
+        while not done:
+            enrollments, next_cursor = self._get_enrollments_list_page(params)
+            for enrollment in enrollments:
+                yield Enrollment(enrollment)
+
+            if next_cursor:
+                params['cursor'] = next_cursor
+            else:
+                done = True
 
     def get_student_enrollments(self):
         """

--- a/edx_api/enrollments/fixtures/enrollments_list.json
+++ b/edx_api/enrollments/fixtures/enrollments_list.json
@@ -1,0 +1,30 @@
+[
+    {
+        "course_id": "course-v1:OpenCraft+OC101+2018_T2",
+        "created": "2019-04-04T19:44:31.802434Z",
+        "is_active": true,
+        "mode": "audit",
+        "user": "staff"
+    },
+    {
+        "course_id": "course-v1:OpenCraft+OC101+2018_T2",
+        "created": "2019-04-04T19:44:31.802434Z",
+        "is_active": true,
+        "mode": "audit",
+        "user": "username"
+    },
+    {
+        "course_id": "course-v1:edX+DemoX+Demo_Course",
+        "created": "2019-04-04T19:44:31.802434Z",
+        "is_active": true,
+        "mode": "audit",
+        "user": "staff"
+    },
+    {
+        "course_id": "course-v1:edX+DemoX+Demo_Course",
+        "created": "2019-04-04T19:44:31.802434Z",
+        "is_active": true,
+        "mode": "audit",
+        "user": "username"
+    }
+]

--- a/edx_api/enrollments/models.py
+++ b/edx_api/enrollments/models.py
@@ -95,7 +95,7 @@ class Enrollment(object):
     @property
     def course_id(self):
         """Shortcut for a nested property"""
-        return self.course_details.course_id
+        return self.course_details.course_id or self.json.get('course_id')
 
     @property
     def created(self):


### PR DESCRIPTION
#### What are the relevant tickets?

#### What's this PR do?
Enables batch course enrollments queries, filtered either by course id or a list of usernames.

#### Where should the reviewer start?
1. Read the code first.
2. Run integration tests.

#### How should this be manually tested?
- Run integration tests.
- Run this manually in the console:
```python
from edx_api.client import EdxApi
creds = {'access_token': access_token}
client = EdxApi(creds)
client.enrollments.get_enrollments()
# list of all enrollments.
client.enrollments.get_enrollments(course_id='course-v1:edX+DemoX+Demo_Course')
# list of all enrollment in a course
client.enrollments.get_enrollments(usernames=['username1', 'username2'])
# list of all enrollments for a list of usernames
```
#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
