### PR TITLE
BB-1189 Allow to specify enrollment mode when creating enrollment for student.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ validation which is required by the OAuth spec.
 Your edx demo course (course id `course-v1:edX+DemoX+Demo_Course`)
 must be enabled for CCX.
 
+The Course Enrollment integration tests have the following requirements:
+- The `ACCESS_TOKEN` value must match the `settings.EDX_API_TOKEN` value in LMS
+- The user assigned to that `ACCESS_TOKEN` must be an admin in the edX demo course.
+  Adding a user as an admin can be done in Studio (url: `<studio_url>/course_team/course-v1:edX+DemoX+Demo_Course`
+
 ## Release Notes
 
 See the RELEASE.rst file

--- a/edx_api/client.py
+++ b/edx_api/client.py
@@ -35,7 +35,8 @@ class EdxApi(object):
         # generating an EdxApi instance with the proper requester & credentials.
         session = requests.session()
         session.headers.update({
-            'Authorization': 'Bearer {}'.format(self.credentials['access_token'])
+            'Authorization': 'Bearer {}'.format(self.credentials['access_token']),
+            'x-edx-api-key': self.credentials['access_token'],
         })
 
         old_request = session.request

--- a/edx_api/client_test.py
+++ b/edx_api/client_test.py
@@ -14,4 +14,7 @@ def test_request_id_credential():
 
 def test_instantiation_happypath():
     """instantiatable with correct args"""
-    EdxApi({'access_token': 'asdf'})
+    token = 'asdf'
+    client = EdxApi({'access_token': token})
+    assert client.get_requester().headers['Authorization'] == 'Bearer {token}'.format(token=token)
+    assert client.get_requester().headers['x-edx-api-key'] == token

--- a/edx_api/constants.py
+++ b/edx_api/constants.py
@@ -1,0 +1,4 @@
+"""edX api client constants"""
+
+ENROLLMENT_MODE_AUDIT = 'audit'
+ENROLLMENT_MODE_VERIFIED = 'verified'

--- a/edx_api/enrollments/init_test.py
+++ b/edx_api/enrollments/init_test.py
@@ -4,6 +4,7 @@ Tests for the content of the __init__ module
 import json
 import os
 from unittest import TestCase
+
 try:
     from mock import patch
 except ImportError:
@@ -13,6 +14,7 @@ import requests_mock
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 
 from edx_api.client import EdxApi
+from edx_api.constants import ENROLLMENT_MODE_AUDIT, ENROLLMENT_MODE_VERIFIED
 from edx_api.enrollments import CourseEnrollments
 
 
@@ -31,23 +33,96 @@ class EnrollmentsTest(TestCase):
                                'fixtures/enrollments_list.json')) as file_obj:
             cls.enrollments_list_json = json.loads(file_obj.read())
 
-        cls.enrollment_json = cls.enrollments_json[0]
+        cls.enrollment_responses = [
+            {'json': cls.enrollments_json[0], 'status_code': 200},
+            {'json': cls.enrollments_json[1], 'status_code': 200},
+        ]
+
         base_edx_url = 'http://edx.example.com'
         cls.base_url = urljoin(base_edx_url, CourseEnrollments.enrollment_url)
-        client = EdxApi({'access_token': 'foobar'}, cls.base_url)
-        cls.enrollment_client = client.enrollments
+        cls.client = EdxApi({'access_token': 'foobar'}, cls.base_url)
+        cls.enrollment_client = cls.client.enrollments
 
     @requests_mock.mock()
-    def test_create_enrollment(self, mock_req):
+    def test_create_enrollment_value(self, mock_req):
         """
         Tests the post request to create an enrollment.
         This just tests that the client expects a JSON object representing the enrollment.
         """
-        mock_req.post(self.base_url, text=json.dumps(self.enrollment_json))
-        enrollment = self.enrollment_client.create_audit_student_enrollment(
-            self.enrollment_json['course_details']['course_id'])
-        for key, val in enrollment.json.items():
-            assert self.enrollment_json.get(key) == val
+        mock_req.register_uri('POST', self.base_url, self.enrollment_responses)
+        course_id = 'dummy_course_id'
+        returned_enrollments = [
+            self.enrollment_client.create_student_enrollment(course_id),
+            self.enrollment_client.create_audit_student_enrollment(course_id),
+        ]
+        assert [enrollment.json for enrollment in returned_enrollments] == self.enrollments_json
+
+    @requests_mock.mock()
+    def test_create_enrollment_body(self, request_mock):
+        """
+        Tests the post body crafted to create an enrollment.
+        """
+        request_mock.post(self.base_url, json=self.enrollments_json[0])
+        course_id = 'course_id'
+        user = 'user'
+        enrollment_attributes = {
+            'namespace': 'credit',
+            'name': 'provider_id',
+            'value': 'institution_name',
+        }
+        self.enrollment_client.create_student_enrollment(
+            course_id=course_id,
+            mode=ENROLLMENT_MODE_VERIFIED
+        )
+        self.assertDictEqual(
+            request_mock.last_request.json(),
+            {
+                'course_details': {
+                    'course_id': course_id
+                },
+                'mode': ENROLLMENT_MODE_VERIFIED
+            }
+        )
+        self.enrollment_client.create_audit_student_enrollment(course_id=course_id)
+        self.assertDictEqual(
+            request_mock.last_request.json(),
+            {
+                'course_details': {
+                    'course_id': course_id
+                },
+                'mode': ENROLLMENT_MODE_AUDIT
+            }
+        )
+        self.enrollment_client.create_student_enrollment(
+            course_id=course_id,
+            username=user
+        )
+        self.assertDictEqual(
+            request_mock.last_request.json(),
+            {
+                'course_details': {
+                    'course_id': course_id
+                },
+                'mode': ENROLLMENT_MODE_AUDIT,
+                'user': user
+            }
+        )
+        self.enrollment_client.create_student_enrollment(
+            course_id=course_id,
+            username=user,
+            enrollment_attributes=enrollment_attributes
+        )
+        self.assertDictEqual(
+            request_mock.last_request.json(),
+            {
+                'enrollment_attributes': enrollment_attributes,
+                'course_details': {
+                    'course_id': course_id
+                },
+                'mode': ENROLLMENT_MODE_AUDIT,
+                'user': user
+            }
+        )
 
     @patch('edx_api.enrollments.CourseEnrollments._get_enrollments_list_page')
     def test_get_enrollments(self, mock_get_enrollments_list_page):

--- a/edx_api/integration_test.py
+++ b/edx_api/integration_test.py
@@ -12,6 +12,8 @@ This means that you need:
 - a valid access token for the user "staff"
 - another course is available with enrollment open and "staff" NOT enrolled
 - the user staff is enrolled in, at least, two courses
+- make sure LMS's settings.EDX_API_TOKEN value is the same as the token used here
+- make sure user staff is admin in the demo course
 - you run the following code in a python shell inside your devstack
   instance to create a certificate:
 ```
@@ -38,6 +40,7 @@ from requests.exceptions import HTTPError
 from requests import Response, Timeout
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 
+from edx_api.constants import ENROLLMENT_MODE_AUDIT, ENROLLMENT_MODE_VERIFIED
 from .client import EdxApi
 
 
@@ -152,13 +155,33 @@ def test_enrollments():
 
 
 @require_integration_settings_course_id
-def test_create_enrollment():
+def test_create_verified_enrollment():
     """
-    Integration test to enroll the user in a course
+    Integration test to enroll the user in a course with `verified` mode
     """
     api = EdxApi({'access_token': ACCESS_TOKEN}, base_url=BASE_URL)
-    enrollment = api.enrollments.create_audit_student_enrollment(ENROLLMENT_CREATION_COURSE_ID)
+    enrollment = api.enrollments.create_student_enrollment(
+        course_id=ENROLLMENT_CREATION_COURSE_ID,
+        mode=ENROLLMENT_MODE_VERIFIED,
+        username="staff"
+    )
     assert enrollment.course_id == ENROLLMENT_CREATION_COURSE_ID
+    assert enrollment.mode == ENROLLMENT_MODE_VERIFIED
+
+
+@require_integration_settings_course_id
+def test_create_audit_enrollment():
+    """
+    Integration test to enroll the user in a course with `audit` mode
+    """
+    api = EdxApi({'access_token': ACCESS_TOKEN}, base_url=BASE_URL)
+    enrollment = api.enrollments.create_student_enrollment(
+        course_id=ENROLLMENT_CREATION_COURSE_ID,
+        mode=ENROLLMENT_MODE_AUDIT,
+        username="staff"
+    )
+    assert enrollment.course_id == ENROLLMENT_CREATION_COURSE_ID
+    assert enrollment.mode == ENROLLMENT_MODE_AUDIT
 
 
 @require_integration_settings_course_id
@@ -171,7 +194,7 @@ def test_create_enrollment_timeout():
     with patch.object(enrollments.requester, 'post', autospec=True) as post:
         post.side_effect = mocked_timeout
         with pytest.raises(Timeout):
-            enrollments.create_audit_student_enrollment(ENROLLMENT_CREATION_COURSE_ID)
+            enrollments.create_student_enrollment(ENROLLMENT_CREATION_COURSE_ID)
 
 
 @require_integration_settings
@@ -418,7 +441,7 @@ def test_enrollments_list():
         assert enrollment.mode
         assert enrollment.is_active
         assert enrollment.user
-        if enrollment.mode != u'verified':
+        if enrollment.mode != ENROLLMENT_MODE_VERIFIED:
             assert not enrollment.is_verified
         else:
             assert enrollment.is_verified


### PR DESCRIPTION
#### What's this PR do?
Allow to specify the enrollment mode on creation.

#### Where should the reviewer start?
Reading the code

#### How should this be manually tested?
1. Create a `Confidential (Web applications)` client.
2. Create a token using a manually created Grant.
    `curl -vL -X POST -d "grant_type=authorization_code&code=$CODE&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET" http://localhost:8000/oauth2/access_token/`
3. Change LMS `settings.EDX_API_KEY` value to be the same as the key previously created.
4. Make sure the user to which the previously created token created belongs is an `admin` in the course used.
5. Run this in a Django Console.
```python
>>> from edx_api.client import EdxApi
>>> creds = {'access_token': access_token}
>>> client = EdxApi(creds, base_url="http://localhost:18000/")
>>> client.enrollments.get_enrollments()
# list of all enrollments.
>>> client.enrollments.create_student_enrollment(
...     course_id='course-v1:edX+DemoX+Demo_Course',
...     mode='verified',
...     user='staff'
... )
# Make sure the enrollment is created with mode 'verified'
```

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
![Not Bad](https://user-images.githubusercontent.com/4007280/56996154-48e1b380-6b69-11e9-98bf-d3aeacd67552.gif)
