### PR TITLE
Allow for setting api_key to the edX API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Your edx demo course (course id `course-v1:edX+DemoX+Demo_Course`)
 must be enabled for CCX.
 
 The Course Enrollment integration tests have the following requirements:
-- The `ACCESS_TOKEN` value must match the `settings.EDX_API_TOKEN` value in LMS
+- The `API_KEY` value must match the `settings.EDX_API_TOKEN` value in LMS
 - The user assigned to that `ACCESS_TOKEN` must be an admin in the edX demo course.
   Adding a user as an admin can be done in Studio (url: `<studio_url>/course_team/course-v1:edX+DemoX+Demo_Course`
 

--- a/edx_api/client.py
+++ b/edx_api/client.py
@@ -36,7 +36,7 @@ class EdxApi(object):
         session = requests.session()
         session.headers.update({
             'Authorization': 'Bearer {}'.format(self.credentials['access_token']),
-            'x-edx-api-key': self.credentials['access_token'],
+            'X-EdX-Api-Key': self.credentials.get('api_key'),
         })
 
         old_request = session.request

--- a/edx_api/client_test.py
+++ b/edx_api/client_test.py
@@ -15,6 +15,7 @@ def test_request_id_credential():
 def test_instantiation_happypath():
     """instantiatable with correct args"""
     token = 'asdf'
-    client = EdxApi({'access_token': token})
+    api_key = 'api_key'
+    client = EdxApi({'access_token': token, 'api_key': api_key})
     assert client.get_requester().headers['Authorization'] == 'Bearer {token}'.format(token=token)
-    assert client.get_requester().headers['x-edx-api-key'] == token
+    assert client.get_requester().headers['X-EdX-Api-Key'] == api_key

--- a/edx_api/integration_test.py
+++ b/edx_api/integration_test.py
@@ -41,10 +41,11 @@ from requests import Response, Timeout
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 
 from edx_api.constants import ENROLLMENT_MODE_AUDIT, ENROLLMENT_MODE_VERIFIED
-from .client import EdxApi
+from edx_api.client import EdxApi
 
 
 ACCESS_TOKEN = os.getenv('ACCESS_TOKEN')
+API_KEY = os.getenv('API_KEY')
 BASE_URL = os.getenv('BASE_URL', 'http://localhost:8000/')
 ENROLLMENT_CREATION_COURSE_ID = os.getenv('ENROLLMENT_CREATION_COURSE_ID')
 
@@ -110,7 +111,7 @@ def test_course_structure():
     Pull down the course structure and validate it has the correct entries.
     This test assumes that the used user can access the course.
     """
-    api = EdxApi({'access_token': ACCESS_TOKEN}, base_url=BASE_URL)
+    api = EdxApi({'access_token': ACCESS_TOKEN, 'api_key': API_KEY}, base_url=BASE_URL)
     structure = api.course_structure.course_blocks('course-v1:edX+DemoX+Demo_Course', 'staff')
 
     titles = [
@@ -134,7 +135,7 @@ def test_enrollments():
     Enrolls the user in a course and then pulls down the enrollments for the user.
     This assumes that the course in the edX instance is available for enrollment.
     """
-    api = EdxApi({'access_token': ACCESS_TOKEN}, base_url=BASE_URL)
+    api = EdxApi({'access_token': ACCESS_TOKEN, 'api_key': API_KEY}, base_url=BASE_URL)
 
     # the enrollment will be done manually until
     # a client to enroll the student is implemented
@@ -159,7 +160,7 @@ def test_create_verified_enrollment():
     """
     Integration test to enroll the user in a course with `verified` mode
     """
-    api = EdxApi({'access_token': ACCESS_TOKEN}, base_url=BASE_URL)
+    api = EdxApi({'access_token': ACCESS_TOKEN, 'api_key': API_KEY}, base_url=BASE_URL)
     enrollment = api.enrollments.create_student_enrollment(
         course_id=ENROLLMENT_CREATION_COURSE_ID,
         mode=ENROLLMENT_MODE_VERIFIED,
@@ -174,7 +175,7 @@ def test_create_audit_enrollment():
     """
     Integration test to enroll the user in a course with `audit` mode
     """
-    api = EdxApi({'access_token': ACCESS_TOKEN}, base_url=BASE_URL)
+    api = EdxApi({'access_token': ACCESS_TOKEN, 'api_key': API_KEY}, base_url=BASE_URL)
     enrollment = api.enrollments.create_student_enrollment(
         course_id=ENROLLMENT_CREATION_COURSE_ID,
         mode=ENROLLMENT_MODE_AUDIT,
@@ -189,7 +190,7 @@ def test_create_enrollment_timeout():
     """
      Asserts request timeout error on enrollment api
     """
-    api = EdxApi({'access_token': ACCESS_TOKEN}, base_url=BASE_URL)
+    api = EdxApi({'access_token': ACCESS_TOKEN, 'api_key': API_KEY}, base_url=BASE_URL)
     enrollments = api.enrollments
     with patch.object(enrollments.requester, 'post', autospec=True) as post:
         post.side_effect = mocked_timeout


### PR DESCRIPTION
#### What are the relevant tickets?
* BB-1366
* Fixes #57 

#### What's this PR do?
It allow setting the edX API key to enable enrollments for arbitrary users.

#### Where should the reviewer start?
Finding the API key for their devstack, and setting it in the client credentials.

#### How should this be manually tested?
By using the `api.enrollments.create_student_enrollment()` method like so:
```
from edx_api.client import EdxApi
api = EdxApi({"access_token": "135cb73a38d0126a362b65139961641b0f713105", "api_key": "PUT_YOUR_API_KEY_HERE"}, base_url="http://localhost:18000")
api.enrollments.create_student_enrollment(course_id="course-v1:edX+DemoX+Demo_Course", username="verified", mode="audit")
```

#### Any background context you want to provide?
#55 added new functionality which requires the edX api key from `settings.EDX_API_KEY`, but didn't provide a mechanism to set the key. This fixes issue #57 which describes that bug.

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
![Oh crap](https://media.giphy.com/media/1MJ7cRuntKE3C/giphy.gif)