### PR TITLE
Added unenrollment functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ htmlcov/
 .cache/
 .idea/
 .pytest_cache/
+#Ipython/Jupyter Notebook
+.ipynb_checkpoints
+*.ipynb

--- a/edx_api/enrollments/__init__.py
+++ b/edx_api/enrollments/__init__.py
@@ -109,12 +109,12 @@ class CourseEnrollments(object):
 
     def get_student_enrollments(self):
         """
-        Returns an Enrollments object with the user enrollments
+        Returns an Enrollments object with the user enrollments for the user
+        whose access token was provided to the API client.
 
         Returns:
             Enrollments: object representing the student enrollments
         """
-        # the request is done in behalf of the current logged in user
         resp = self.requester.get(
             urljoin(self.base_url, self.enrollment_url))
         resp.raise_for_status()
@@ -144,18 +144,18 @@ class CourseEnrollments(object):
         Returns:
             Enrollment: object representing the student enrollment in the provided course
         """
-        audit_enrollment = {
+        enrollment_data = {
             "mode": mode,
             "course_details": {"course_id": course_id}
         }
         if username:
-            audit_enrollment['user'] = username
+            enrollment_data['user'] = username
         if enrollment_attributes:
-            audit_enrollment['enrollment_attributes'] = enrollment_attributes
+            enrollment_data['enrollment_attributes'] = enrollment_attributes
         # the request is done in behalf of the current logged in user
         resp = self.requester.post(
             urljoin(self.base_url, self.enrollment_url),
-            json=audit_enrollment
+            json=enrollment_data
         )
         resp.raise_for_status()
         return Enrollment(resp.json())
@@ -176,3 +176,25 @@ class CourseEnrollments(object):
             mode=ENROLLMENT_MODE_AUDIT,
             username=username
         )
+
+    def deactivate_enrollment(self, course_id):
+        """
+        Deactivates an enrollment in the given course for the user
+        whose access token was provided to the API client (in other words, the
+        user will be unenrolled)
+
+        Args:
+            course_id (str): An edX course id.
+
+        Returns:
+            Enrollment: object representing the deactivated student enrollment
+        """
+        resp = self.requester.post(
+            urljoin(self.base_url, self.enrollment_url),
+            json={
+                "course_details": {"course_id": course_id},
+                "is_active": False,
+            }
+        )
+        resp.raise_for_status()
+        return Enrollment(resp.json())

--- a/edx_api/integration_test.py
+++ b/edx_api/integration_test.py
@@ -46,7 +46,7 @@ from edx_api.client import EdxApi
 
 ACCESS_TOKEN = os.getenv('ACCESS_TOKEN')
 API_KEY = os.getenv('API_KEY')
-BASE_URL = os.getenv('BASE_URL', 'http://localhost:8000/')
+BASE_URL = os.getenv('BASE_URL', 'http://localhost:18000/')
 ENROLLMENT_CREATION_COURSE_ID = os.getenv('ENROLLMENT_CREATION_COURSE_ID')
 
 # pylint: disable=invalid-name
@@ -183,6 +183,23 @@ def test_create_audit_enrollment():
     )
     assert enrollment.course_id == ENROLLMENT_CREATION_COURSE_ID
     assert enrollment.mode == ENROLLMENT_MODE_AUDIT
+
+
+@require_integration_settings_course_id
+def test_deactivate_enrollment():
+    """
+    Integration test to enroll then deactivate a user in a course
+    """
+    api = EdxApi({'access_token': ACCESS_TOKEN, 'api_key': API_KEY}, base_url=BASE_URL)
+    api.enrollments.create_student_enrollment(
+        course_id=ENROLLMENT_CREATION_COURSE_ID,
+        mode=ENROLLMENT_MODE_AUDIT
+    )
+    deactivated_enrollment = api.enrollments.deactivate_enrollment(
+        course_id=ENROLLMENT_CREATION_COURSE_ID
+    )
+    assert deactivated_enrollment.course_id == ENROLLMENT_CREATION_COURSE_ID
+    assert deactivated_enrollment.is_active is False
 
 
 @require_integration_settings_course_id

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
 coverage
 fabric
 flake8
-ipdb
+pdbpp
 mixer
 mock
 tox


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #60 

#### What's this PR do?
Adds an API method to allow the user to deactivate an enrollment (i.e.: unenroll) from a course

#### How should this be manually tested?

First, run devstack (or point this script at a live LMS). This snippet will test the unenrollment function:

```
access_token = <access token value associated with some user in edX>
api_key = "PUT_YOUR_API_KEY_HERE" # ...or whatever the API key is for your live LMS
base_url = "http://edx.odl.local:18000" # ...or the live LMS URL
course_id = "course-v1:edX+DemoX+Demo_Course" # ...or some other available course id

client = EdxApi(
    {
        'access_token': access_token,
        'api_key': api_key
    }, 
    base_url=base_url
)
client.enrollments.create_student_enrollment(course_id)
deactivated_enrollment = client.enrollments.deactivate_enrollment(course_id)
```

`deactivated_enrollment` should have `is_active=False`, and on the LMS dashboard for that user,   you should not see the course associated with the above id