### PR TITLE
Update CourseDetails client to pass username

### DIFF
--- a/edx_api/course_detail/__init__.py
+++ b/edx_api/course_detail/__init__.py
@@ -13,7 +13,7 @@ class CourseDetails(object):
         self._requester = requester
         self._base_url = base_url
 
-    def get_detail(self, course_id):
+    def get_detail(self, course_id, username=None):
         """
         Fetches course details.
 
@@ -23,13 +23,22 @@ class CourseDetails(object):
         Returns:
             CourseDetail
         """
-        # the request is done in behalf of the current logged in user
-        resp = self._requester.get(
-            urljoin(
-                self._base_url,
-                '/api/courses/v1/courses/{course_key}/'.format(course_key=course_id)
-            )
-        )
+        # the request is done on behalf of the current logged in user
+        # this only works if COURSE_ABOUT_VISIBILITIY_PERMISSION is not
+        # set to staff, otherwise you need to pass in a username with
+        # permissions.
+        if not username:
+            resp = self._requester.get(urljoin
+                                       (self._base_url,
+                                        '/api/courses/v1/courses/{course_key}'
+                                        .format(course_key=course_id)))
+        else:
+            resp = self._requester.get(urljoin
+                                       (self._base_url,
+                                        '/api/courses/v1/courses/{course_key}/'
+                                        '?username={username}'
+                                        .format(course_key=course_id,
+                                                username=username)))
 
         resp.raise_for_status()
 


### PR DESCRIPTION
#### What are the relevant tickets?
[Issue#64](https://github.com/mitodl/edx-api-client/issues/64)

#### What's this PR do?
Updates CourseDetails client to pass username

#### How should this be manually tested?
Test out the client locally by establishing a session to an openedx instance and passing in a `course_id` along with a `username` that has the right permissions and ensure that course details are returned. What's easy to miss is that if the configuration on the openedx instance has course listing and visibility publicly available, there is no need to pass in a username.
