### PR TITLE
#64 Pass username in course detail request

### DIFF
--- a/edx_api/course_detail/__init__.py
+++ b/edx_api/course_detail/__init__.py
@@ -9,27 +9,33 @@ class CourseDetails(object):
     """
     API Client to interface with the course detail API.
     """
+
     def __init__(self, requester, base_url):
         self._requester = requester
         self._base_url = base_url
 
-    def get_detail(self, course_id):
+    def get_detail(self, course_id, username=None):
         """
         Fetches course details.
 
         Args:
             course_id (str): An edx course id.
+            username (str): an edx user's username
 
         Returns:
             CourseDetail
         """
-        # the request is done in behalf of the current logged in user
-        resp = self._requester.get(
-            urljoin(
-                self._base_url,
-                '/api/courses/v1/courses/{course_key}/'.format(course_key=course_id)
-            )
+        # The request may be done on behalf of the user (username) provided. Depending
+        # on the way edX is set up, the course detail may be limited to `staff` only users.
+        # Not specifying a username results in request being performed on behalf of
+        # an AnonymousUser.
+        url = urljoin(
+            self._base_url,
+            '/api/courses/v1/courses/{course_key}/'.format(course_key=course_id)
         )
+        if username:
+            url = '{url}?username={username}'.format(url=url, username=username)
+        resp = self._requester.get(url)
 
         resp.raise_for_status()
 


### PR DESCRIPTION
#### What are the relevant tickets?
#64 

#### What's this PR do?
Adds an optional `username` parameter to `CourseDetails.get_detail` method in order to the request on behalf of a specified user.

#### Where should the reviewer start?

#### How should this be manually tested?
With edX set up to have course detail visibility to `staff` users, run this method with both the access token and username attributed to an edX user who has at least a `staff` level access. The method should return expected course details. Re-run with the username removed, the request should raise a 404 error.


#### Any background context you want to provide?
Previously the way this was implemented, although the edx API access token was provided, the `username` field was left blank in the request. This resulted in the request being attributed to an `AnonymousUser` on edX's side. If edX had been set up with course detail visibility anything but public this request would raise a 404. This PR takes care of that. 