### PR TITLE
Added api to update user's name in edX

### DIFF
--- a/edx_api/ccx.py
+++ b/edx_api/ccx.py
@@ -48,7 +48,7 @@ class CCX(object):
 
         try:
             resp.raise_for_status()
-        except:
+        except Exception:
             log.error(resp.json())
             raise
 

--- a/edx_api/certificates/models_test.py
+++ b/edx_api/certificates/models_test.py
@@ -39,8 +39,9 @@ class CertificatesTests(TestCase):
 
     def test_courses_verified_cert(self):
         """Test for all_courses_verified_certs"""
-        assert (list(self.certificates.all_courses_verified_certs) ==
-                ["course-v1:edX+DemoX+Demo_Course"])
+        assert list(self.certificates.all_courses_verified_certs) == [
+            "course-v1:edX+DemoX+Demo_Course"
+        ]
 
     def test_all_cert(self):
         """Test for all_certs"""

--- a/edx_api/course_structure/__init__.py
+++ b/edx_api/course_structure/__init__.py
@@ -1,7 +1,7 @@
 """Course Structure API"""
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 
-from .models import Structure, Block
+from .models import Structure
 
 
 class CourseStructure(object):

--- a/edx_api/integration_test.py
+++ b/edx_api/integration_test.py
@@ -466,3 +466,15 @@ def test_enrollments_list():
         cnt += 1
 
     assert cnt >= 2
+
+
+@require_integration_settings
+def test_user_name_update():
+    """
+    Asserts that update user's name api updates the full name of the user correctly.
+    """
+    api = EdxApi({'access_token': ACCESS_TOKEN}, base_url=BASE_URL)
+    user_name = 'Test Name'
+    updated_user = api.user_info.update_user_name('staff', user_name)
+    assert updated_user.username == 'staff'
+    assert updated_user.name == user_name

--- a/edx_api/user_info/__init__.py
+++ b/edx_api/user_info/__init__.py
@@ -36,3 +36,34 @@ class UserInfo(object):
         resp.raise_for_status()
 
         return Info(resp.json())
+
+    def update_user_name(self, username, user_full_name):
+        """
+        Updates Full-Name of the user
+
+        Args:
+            username (user.models.User): Username of the Application user
+            user_full_name: Full name to be replace/updated with old full name
+
+        Returns:
+            UserInfo: Object with user details for whom the name is updated
+        """
+        user_name_data = dict(name=user_full_name)
+
+        # the request is done on behalf of the current logged in user
+        self.requester.headers.update(
+            {
+                "Accept": "application/json, text/javascript, */*; q=0.01",
+                "X-Requested-With": "XMLHttpRequest",
+                "Content-Type": "application/merge-patch+json",
+            }
+        )
+        resp = self.requester.patch(
+            urljoin(
+                self.base_url,
+                '/api/user/v1/accounts/{username}'.format(username=username)
+            ),
+            json=user_name_data)
+        resp.raise_for_status()
+
+        return Info(resp.json())

--- a/edx_api/user_info/__init__.py
+++ b/edx_api/user_info/__init__.py
@@ -37,18 +37,18 @@ class UserInfo(object):
 
         return Info(resp.json())
 
-    def update_user_name(self, username, user_full_name):
+    def update_user_name(self, username, full_name):
         """
-        Updates Full-Name of the user
+        Updates full name of the user
 
         Args:
-            username (user.models.User): Username of the Application user
-            user_full_name: Full name to be replace/updated with old full name
+            username (str): Username of the Application user
+            full_name (str): Full name that will replace the user's existing full name
 
         Returns:
-            UserInfo: Object with user details for whom the name is updated
+            UserInfo: Object representing the edX user
         """
-        user_name_data = dict(name=user_full_name)
+        request_data = dict(name=full_name)
 
         # the request is done on behalf of the current logged in user
         self.requester.headers.update(
@@ -63,7 +63,7 @@ class UserInfo(object):
                 self.base_url,
                 '/api/user/v1/accounts/{username}'.format(username=username)
             ),
-            json=user_name_data)
+            json=request_data)
         resp.raise_for_status()
 
         return Info(resp.json())

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --cov edx_api --pep8 --pylint --cov-report term --cov-report html
+addopts = --cov edx_api --flake8 --pylint --cov-report term --cov-report html
 norecursedirs = .git .tox .* CVS _darcs {arch} *.egg
-pep8maxlinelength = 119
+flake8-max-line-length = 119
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ def read(filename):
     except IOError:
         return ''
 
+
 setup(
     name="edx-api-client",
     version=edx_api.__version__,

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,8 +6,8 @@ mixer
 mock
 tox
 pylint==1.6.5
-pytest
-pytest-pep8
+pytest>0, <4.6.11
+pytest-flake8
 pytest-pylint==0.6.0
 pytest-cov
 ipython


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #69 

#### What's this PR do?
- Adds API for updating the name of User in edX.
- Migrates from `pep8` to `flake8` as CI checks were failing 

#### How should this be manually tested?
- Integrate this branch of `edx-api-client` and use `update_user_name` method from `user_info` to perform update name api.
- For testing make sure that your edX instance is running.

#### Any background context you want to provide?
We did some work on updating the user's name but we created the API there instead of the client, So we added some tech debt and enhancement issues to do this in a better way.
https://github.com/mitodl/mitxpro/pull/1958#discussion_r508200871
