### PR TITLE
removing mixer

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,7 +2,6 @@ coverage
 fabric
 flake8
 pdbpp
-mixer
 mock
 tox
 pylint==1.6.5


### PR DESCRIPTION
### Related Issue
Fixes https://github.com/mitodl/edx-api-client/issues/77

### Description
CI tests were failing due to an incompatible dependency named `mixer`. We are not using this dependency anymore so removing it solved our issue.
