### PR TITLE
Remove the check for username to match the grade username

### DIFF
--- a/edx_api/grades/models.py
+++ b/edx_api/grades/models.py
@@ -66,10 +66,6 @@ class CurrentGradesByUser(CurrentGrades):
         for current_grade in current_grade_list:
             if not isinstance(current_grade, CurrentGrade):
                 raise ValueError("Only CurrentGrade objects are allowed")
-            if self.username is None:
-                self.username = current_grade.username
-            if self.username is not None and current_grade.username != self.username:
-                raise ValueError("Only CurrentGrade objects for the same user are allowed")
             self.current_grades[current_grade.course_id] = current_grade
 
     def __str__(self):

--- a/edx_api/grades/models_test.py
+++ b/edx_api/grades/models_test.py
@@ -96,12 +96,11 @@ class CurrentGradesByUserTests(TestCase):
             "course-v1:edX+DemoX+Demo_Course", "course-v1:MITx+8.MechCX+2014_T1"
         }
 
-    def test_only_same_user_grades(self):
-        """CurrentGradesByUser can contain only grades for the same user"""
+    def test_username_is_different(self):
+        """CurrentGradesByUser can contain grades for the user with different username"""
         grades_json = deepcopy(self.grades_json)
         grades_json[0]['username'] = 'other_random_string'
-        with self.assertRaises(ValueError):
-            CurrentGradesByUser([CurrentGrade(json_obj) for json_obj in grades_json])
+        CurrentGradesByUser([CurrentGrade(json_obj) for json_obj in grades_json])
 
     def test_get_current_grade(self):
         """Test for get_current_grade method"""


### PR DESCRIPTION
#### What are the relevant tickets?
Fix https://github.com/mitodl/micromasters/issues/5018

#### What's this PR do?
Remove the requirement for users username to match the username in the grade data.
