### PR TITLE
feat: add course pacing property

### DIFF
--- a/edx_api/course_detail/fixtures/course_detail.json
+++ b/edx_api/course_detail/fixtures/course_detail.json
@@ -21,5 +21,6 @@
     "start_display": "March 25, 2016",
     "start_type": "timestamp",
     "course_id": "course-v1:edX+DemoX+Demo_Course",
-    "overview": "<h2>About This Course</h2>\n   <p>Include your long course description here. The long course description should contain 150-400 words.</p>\n"
+    "overview": "<h2>About This Course</h2>\n   <p>Include your long course description here. The long course description should contain 150-400 words.</p>\n",
+    "pacing": "self"
 }

--- a/edx_api/course_detail/models.py
+++ b/edx_api/course_detail/models.py
@@ -122,6 +122,20 @@ class CourseDetail(object):
         for media_type, url_dict in self.json.get("media", {}).items():
             yield Media(type=media_type, url=url_dict.get("uri"))
 
+    @property
+    def pacing(self):
+        """
+        Pacing of a course. Possible values are ("self" or "instructor")
+        """
+        return self.json.get("pacing")
+
+    def is_self_paced(self):
+        """
+        Helper function to check if a course is self paced
+        Note: This property is not part of course detail API, It's calculated on base of course pacing
+        """
+        return self.pacing == "self"
+
 
 class CourseMode(object):
     """

--- a/edx_api/course_detail/models_test.py
+++ b/edx_api/course_detail/models_test.py
@@ -107,6 +107,14 @@ class CourseDetailTests(TestCase):
         )
         assert Media(type="course_video", url=None) in list_media
 
+    def test_pacing(self):
+        """Test for pacing property"""
+        assert self.detail.pacing == "self"
+
+    def test_is_self_paced(self):
+        """Test for is_self_paced helper function"""
+        assert self.detail.is_self_paced() is True
+
 
 class CourseModeTests(TestCase):
     """Tests for course mode object"""
@@ -130,7 +138,7 @@ class CourseModeTests(TestCase):
 
     def test_mode_slug(self):
         """Test for mode_slug property"""
-        assert self.detail.mode_slug == ("string")
+        assert self.detail.mode_slug == "string"
 
     def test_mode_display_name(self):
         """Test for mode_display_name property"""


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1155

#### What's this PR do?
- Adds pacing property from course detail response of edX
- Adds helper method to check if a course is `self_paced`

#### Where should the reviewer start?
- You can easily test this in conjunction with its counterpart PR in MITxOnline https://github.com/mitodl/mitxonline/pull/1158
- Just follow the testing steps in the above-mentioned PR.
- If you want to test it independently, Create APIClient for CourseDetails and then call `get_detail` function with course id/key passed into that

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
