### PR TITLE
feat: add certificate_available_date in course detail

### DIFF
--- a/edx_api/course_detail/models.py
+++ b/edx_api/course_detail/models.py
@@ -57,6 +57,14 @@ class CourseDetail(object):
             return None
 
     @property
+    def certificate_available_date(self):
+        """Date certificates are made available"""
+        try:
+            return parser.parse(self.json.get("certificate_available_date"))
+        except (AttributeError, TypeError):
+            return None
+
+    @property
     def course_id(self):
         """
         A unique identifier of the course; a serialized representation


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/1340

#### What's this PR do?
- Adds `certificate_available_date` in the course detail API

#### Where should the reviewer start?
Follow the instruction mentioned in https://github.com/mitodl/mitxonline/pull/1478

#### How should this be manually tested?
Follow the instruction mentioned in https://github.com/mitodl/mitxonline/pull/1478

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
