### PR TITLE
refactor: remove X-EdX-Api-Key usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,3 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage.xml
-          fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.5"
+        env:
+          PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
 
       - id: cache
         uses: actions/cache@v1

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Your edx demo course (course id `course-v1:edX+DemoX+Demo_Course`)
 must be enabled for CCX.
 
 The Course Enrollment integration tests have the following requirements:
-- The `API_KEY` value must match the `settings.EDX_API_TOKEN` value in LMS
 - The user assigned to that `ACCESS_TOKEN` must be an admin in the edX demo course.
   Adding a user as an admin can be done in Studio (url: `<studio_url>/course_team/course-v1:edX+DemoX+Demo_Course`
 

--- a/edx_api/client.py
+++ b/edx_api/client.py
@@ -43,8 +43,7 @@ class EdxApi(object):
             {
                 "Authorization": "{} {}".format(
                     token_type, self.credentials["access_token"]
-                ),
-                "X-EdX-Api-Key": self.credentials.get("api_key"),
+                )
             }
         )
 

--- a/edx_api/client_test.py
+++ b/edx_api/client_test.py
@@ -15,7 +15,5 @@ def test_request_id_credential():
 def test_instantiation_happypath():
     """instantiatable with correct args"""
     token = 'asdf'
-    api_key = 'api_key'
-    client = EdxApi({'access_token': token, 'api_key': api_key})
+    client = EdxApi({'access_token': token})
     assert client.get_requester().headers['Authorization'] == 'Bearer {token}'.format(token=token)
-    assert client.get_requester().headers['X-EdX-Api-Key'] == api_key

--- a/edx_api/enrollments/__init__.py
+++ b/edx_api/enrollments/__init__.py
@@ -201,24 +201,27 @@ class CourseEnrollments(object):
             username=username
         )
 
-    def deactivate_enrollment(self, course_id):
+    def deactivate_enrollment(self, course_id, username=None):
         """
         Deactivates an enrollment in the given course for the user
-        whose access token was provided to the API client (in other words, the
-        user will be unenrolled)
 
         Args:
             course_id (str): An edX course id.
+            username (str): Username.
 
         Returns:
             Enrollment: object representing the deactivated student enrollment
         """
+
+        params = {
+            "course_details": {"course_id": course_id},
+            "is_active": False,
+        }
+        if username:
+            params['user'] = username
         resp = self.requester.post(
             urljoin(self.base_url, self.enrollment_url),
-            json={
-                "course_details": {"course_id": course_id},
-                "is_active": False,
-            }
+            json=params
         )
         resp.raise_for_status()
         return Enrollment(resp.json())

--- a/edx_api/enrollments/init_test.py
+++ b/edx_api/enrollments/init_test.py
@@ -172,14 +172,18 @@ class EnrollmentsTest(TestCase):
         """
         request_mock.post(self.enrollment_url, json=self.enrollments_json[0])
         course_id = 'course_id'
-        returned_enrollment = self.enrollment_client.deactivate_enrollment(course_id=course_id)
+        user = 'user'
+        returned_enrollment = self.enrollment_client.deactivate_enrollment(
+            course_id=course_id, username=user
+        )
         self.assertDictEqual(
             request_mock.last_request.json(),
             {
                 'course_details': {
                     'course_id': course_id
                 },
-                'is_active': False
+                'is_active': False,
+                'user': user
             }
         )
         assert returned_enrollment.json == self.enrollments_json[0]

--- a/edx_api/integration_test.py
+++ b/edx_api/integration_test.py
@@ -45,7 +45,6 @@ from edx_api.client import EdxApi
 
 
 ACCESS_TOKEN = os.getenv('ACCESS_TOKEN')
-API_KEY = os.getenv('API_KEY')
 BASE_URL = os.getenv('BASE_URL', 'http://localhost:18000/')
 ENROLLMENT_CREATION_COURSE_ID = os.getenv('ENROLLMENT_CREATION_COURSE_ID')
 
@@ -111,7 +110,7 @@ def test_course_structure():
     Pull down the course structure and validate it has the correct entries.
     This test assumes that the used user can access the course.
     """
-    api = EdxApi({'access_token': ACCESS_TOKEN, 'api_key': API_KEY}, base_url=BASE_URL)
+    api = EdxApi({'access_token': ACCESS_TOKEN}, base_url=BASE_URL)
     structure = api.course_structure.course_blocks('course-v1:edX+DemoX+Demo_Course', 'staff')
 
     titles = [
@@ -135,7 +134,7 @@ def test_enrollments():
     Enrolls the user in a course and then pulls down the enrollments for the user.
     This assumes that the course in the edX instance is available for enrollment.
     """
-    api = EdxApi({'access_token': ACCESS_TOKEN, 'api_key': API_KEY}, base_url=BASE_URL)
+    api = EdxApi({'access_token': ACCESS_TOKEN}, base_url=BASE_URL)
 
     # the enrollment will be done manually until
     # a client to enroll the student is implemented
@@ -160,7 +159,7 @@ def test_create_verified_enrollment():
     """
     Integration test to enroll the user in a course with `verified` mode
     """
-    api = EdxApi({'access_token': ACCESS_TOKEN, 'api_key': API_KEY}, base_url=BASE_URL)
+    api = EdxApi({'access_token': ACCESS_TOKEN}, base_url=BASE_URL)
     enrollment = api.enrollments.create_student_enrollment(
         course_id=ENROLLMENT_CREATION_COURSE_ID,
         mode=ENROLLMENT_MODE_VERIFIED,
@@ -175,7 +174,7 @@ def test_create_audit_enrollment():
     """
     Integration test to enroll the user in a course with `audit` mode
     """
-    api = EdxApi({'access_token': ACCESS_TOKEN, 'api_key': API_KEY}, base_url=BASE_URL)
+    api = EdxApi({'access_token': ACCESS_TOKEN}, base_url=BASE_URL)
     enrollment = api.enrollments.create_student_enrollment(
         course_id=ENROLLMENT_CREATION_COURSE_ID,
         mode=ENROLLMENT_MODE_AUDIT,
@@ -190,7 +189,7 @@ def test_deactivate_enrollment():
     """
     Integration test to enroll then deactivate a user in a course
     """
-    api = EdxApi({'access_token': ACCESS_TOKEN, 'api_key': API_KEY}, base_url=BASE_URL)
+    api = EdxApi({'access_token': ACCESS_TOKEN}, base_url=BASE_URL)
     api.enrollments.create_student_enrollment(
         course_id=ENROLLMENT_CREATION_COURSE_ID,
         mode=ENROLLMENT_MODE_AUDIT
@@ -207,7 +206,7 @@ def test_create_enrollment_timeout():
     """
      Asserts request timeout error on enrollment api
     """
-    api = EdxApi({'access_token': ACCESS_TOKEN, 'api_key': API_KEY}, base_url=BASE_URL)
+    api = EdxApi({'access_token': ACCESS_TOKEN}, base_url=BASE_URL)
     enrollments = api.enrollments
     with patch.object(enrollments.requester, 'post', autospec=True) as post:
         post.side_effect = mocked_timeout


### PR DESCRIPTION
### What are the relevant tickets?
[#103](https://github.com/mitodl/edx-api-client/issues/103)

### Description (What does it do?)
This PR removes the usage of X-EdX-Api-Key as Open edX is planning to deprecate the EDX_API_KEY. More details can be found at https://github.com/openedx/edx-platform/issues/34039. The X-EdX-Api-Key permission scheme is introduced to the EdX API to allow both server-to-server access and authenticated user access. It is specifically introduced for the enrollment API (and potentially other APIs) to grant requests that use the API key access to view and modify other users' enrollments. Therefore, we need to ensure that any functionality using the enrollment and other APIs functions properly without the X-EdX-Api-Key.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

- Fetch, check out to this branch, install `edx-api-client` with editable mode, and make sure edx is configured.
- Test all the endpoints that currently use X-EdX-Api-Key for client requests. These should be tested thoroughly as this header will now be removed.
   - `course_structure`
   - `course_detail`
   - `course_mode`
   - `enrollments`
   - `ccx`
   - `email_settings`
   - `certificates`
   - `user_info`
   - `bulk_user_retirement`
- Most of the endpoints can be tested manually using xpro, such as registering a user or enrolling in a course. However, testers can also use management commands to validate APIs. Some of these commands are listed below:
   - `create_enrollment`
   - `sync_grades_and_certificates`
   - `sync_courseruns`
   or by manually calling some tasks if the following tasks call the corresponding APIs on edX :
   - `generate_course_certificates`
   - `sync_courseruns_data`
   - `change_edx_user_email_async`
   - `change_edx_user_name_async`
   - `create_edx_user_from_id`
   - `create_user_from_id`

Important to be tested:
- Test user enrollment with different course "privileged" modes, i.e., `no-id-professional`, `audit`, and `verified`.
   - For xpro, we use `no-id-professional` as the default mode. If there is a failover, we try to enroll the user in `audit` mode. However, the process may vary for mitxonline.
   - This is how I tested, But It would be good if the tester tests the different enrollment through front-end.
```
from edx_api.client import EdxApi
api = EdxApi({"access_token": "<ACCESS_TOKEN>"}, base_url="http://host.docker.internal:18000")
api.enrollments.create_student_enrollment(course_id="course-v1:edX+DemoX+Demo_Course", username="verified", mode="audit")
```
- Test the [deactivate_enrollment](https://github.com/mitodl/edx-api-client/blob/master/edx_api/enrollments/__init__.py#L204) API, here are the few Xpro features/management commands I found that directly or indirectly use this API.
   - `defer_enrollment`
   - `refund_enrollment`
   - `transfer_enrollment`
   - `sheets.tasks.handle_unprocessed_deferral_requests`
   -  `sheets.tasks.handle_unprocessed_refund_requests`

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
