### PR TITLE
chore: bump python to 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.9"
-        env:
-          PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
 
       - id: cache
         uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.5"
+          python-version: "3.9"
         env:
           PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
 

--- a/edx_api/__init__.py
+++ b/edx_api/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 edX python REST API client
 """

--- a/edx_api/bulk_user_retirement.py
+++ b/edx_api/bulk_user_retirement.py
@@ -7,7 +7,7 @@ from urllib import parse
 log = logging.getLogger(__name__)
 
 
-class BulkUserRetirement(object):
+class BulkUserRetirement:
     """
     API client for interacting with user retirement API
     """

--- a/edx_api/ccx.py
+++ b/edx_api/ccx.py
@@ -8,7 +8,7 @@ from urllib import parse
 log = logging.getLogger(__name__)
 
 
-class CCX(object):
+class CCX:
     """
     API Client for interacting w/ CCXs
     """

--- a/edx_api/ccx_test.py
+++ b/edx_api/ccx_test.py
@@ -3,7 +3,7 @@ import json
 import os.path
 import requests
 
-from mock import create_autospec
+from unittest.mock import create_autospec
 from .ccx import CCX
 
 

--- a/edx_api/certificates/__init__.py
+++ b/edx_api/certificates/__init__.py
@@ -8,7 +8,7 @@ from edx_api.enrollments import CourseEnrollments
 from .models import Certificate, Certificates
 
 
-class UserCertificates(object):
+class UserCertificates:
     """
     edX student certificates client
     """
@@ -37,10 +37,7 @@ class UserCertificates(object):
         resp = self.requester.get(
             urljoin(
                 self.base_url,
-                '/api/certificates/v0/certificates/{username}/courses/{course_key}/'.format(
-                    username=username,
-                    course_key=course_id
-                )
+                f'/api/certificates/v0/certificates/{username}/courses/{course_id}/'
             )
         )
 

--- a/edx_api/certificates/models.py
+++ b/edx_api/certificates/models.py
@@ -4,7 +4,7 @@ Business objects for the certificates API
 from dateutil import parser
 
 
-class Certificates(object):
+class Certificates:
     """
     The certificates object
     This assumes that there can be only one certificate
@@ -56,7 +56,7 @@ class Certificates(object):
         return course_id in self.verified_certificates
 
 
-class Certificate(object):
+class Certificate:
     """
     The certificate object
     """
@@ -64,10 +64,7 @@ class Certificate(object):
         self.json = json
 
     def __str__(self):
-        return "<Certificate for user {username} for course {course_id}>".format(
-            username=self.username,
-            course_id=self.course_id
-        )
+        return f"<Certificate for user {self.username} for course {self.course_id}>"
 
     @property
     def is_verified(self):

--- a/edx_api/client.py
+++ b/edx_api/client.py
@@ -14,7 +14,7 @@ from .grades import UserCurrentGrades
 from .user_info import UserInfo
 
 
-class EdxApi(object):
+class EdxApi:
     """
     A client for speaking with edX.
     """
@@ -41,9 +41,7 @@ class EdxApi(object):
         session = requests.session()
         session.headers.update(
             {
-                "Authorization": "{} {}".format(
-                    token_type, self.credentials["access_token"]
-                )
+                "Authorization": f"{token_type} {self.credentials['access_token']}"
             }
         )
 

--- a/edx_api/client_test.py
+++ b/edx_api/client_test.py
@@ -16,4 +16,4 @@ def test_instantiation_happypath():
     """instantiatable with correct args"""
     token = 'asdf'
     client = EdxApi({'access_token': token})
-    assert client.get_requester().headers['Authorization'] == 'Bearer {token}'.format(token=token)
+    assert client.get_requester().headers['Authorization'] == f'Bearer {token}'

--- a/edx_api/course_detail/__init__.py
+++ b/edx_api/course_detail/__init__.py
@@ -5,7 +5,7 @@ from .models import CourseDetail, CourseMode
 
 
 # pylint: disable=too-few-public-methods
-class CourseDetails(object):
+class CourseDetails:
     """
     API Client to interface with the course detail API.
     """
@@ -32,17 +32,15 @@ class CourseDetails(object):
             resp = self._requester.get(
                 urljoin(
                     self._base_url,
-                    "/api/courses/v1/courses/{course_key}".format(course_key=course_id),
+                    f"/api/courses/v1/courses/{course_id}",
                 )
             )
         else:
             resp = self._requester.get(
                 urljoin(
                     self._base_url,
-                    "/api/courses/v1/courses/{course_key}/"
-                    "?username={username}".format(
-                        course_key=course_id, username=username
-                    ),
+                    f"/api/courses/v1/courses/{course_id}/"
+                    "?username={username}"
                 )
             )
 
@@ -51,7 +49,7 @@ class CourseDetails(object):
         return CourseDetail(resp.json())
 
 
-class CourseModes(object):
+class CourseModes:
     """
     API Client to interface with the course modes API.
     """
@@ -73,9 +71,7 @@ class CourseModes(object):
         resp = self._requester.get(
             urljoin(
                 self._base_url,
-                "/api/course_modes/v1/courses/{course_key}".format(
-                    course_key=course_id
-                ),
+                f"/api/course_modes/v1/courses/{course_id}",
             )
         )
 

--- a/edx_api/course_detail/__init__.py
+++ b/edx_api/course_detail/__init__.py
@@ -39,8 +39,7 @@ class CourseDetails:
             resp = self._requester.get(
                 urljoin(
                     self._base_url,
-                    f"/api/courses/v1/courses/{course_id}/"
-                    "?username={username}"
+                    f"/api/courses/v1/courses/{course_id}/?username={username}"
                 )
             )
 

--- a/edx_api/course_detail/models.py
+++ b/edx_api/course_detail/models.py
@@ -8,7 +8,7 @@ from dateutil import parser
 Media = namedtuple("Media", ["type", "url"])
 
 
-class CourseDetail(object):
+class CourseDetail:
     """
     The course detail object
     """
@@ -17,7 +17,7 @@ class CourseDetail(object):
         self.json = payload
 
     def __str__(self):
-        return "<Course detail for {}>".format(self.course_id)
+        return f"<Course detail for {self.course_id}>"
 
     def __repr__(self):
         return self.__str__()
@@ -145,7 +145,7 @@ class CourseDetail(object):
         return self.pacing == "self"
 
 
-class CourseMode(object):
+class CourseMode:
     """
     The course mode object
     """
@@ -154,7 +154,7 @@ class CourseMode(object):
         self.json = payload
 
     def __str__(self):
-        return "<Course mode for {}>".format(self.course_id)
+        return f"<Course mode for {self.course_id}>"
 
     def __repr__(self):
         return self.__str__()

--- a/edx_api/course_structure/__init__.py
+++ b/edx_api/course_structure/__init__.py
@@ -4,7 +4,7 @@ from urllib.parse import urljoin
 from .models import Structure
 
 
-class CourseStructure(object):
+class CourseStructure:
     """
     API Client to interface with the course structure API.
     """

--- a/edx_api/course_structure/models.py
+++ b/edx_api/course_structure/models.py
@@ -1,7 +1,7 @@
 """Business objects for the course structure API"""
 
 
-class Structure(object):
+class Structure:
     """
     The course structure object, which represents a tree of nodes.
     """
@@ -25,10 +25,10 @@ class Structure(object):
         return Block(root_id, self.payload)
 
     def __str__(self):
-        return 'Structure for {}'.format(self._root_id)
+        return f'Structure for {self._root_id}'
 
 
-class Block(object):
+class Block:
     """
     Represents a single block within the course structure.
     """

--- a/edx_api/email_settings.py
+++ b/edx_api/email_settings.py
@@ -7,7 +7,7 @@ from urllib import parse
 log = logging.getLogger(__name__)
 
 
-class EmailSettings(object):
+class EmailSettings:
     """
     API client for interacting with email settings
     """

--- a/edx_api/enrollments/__init__.py
+++ b/edx_api/enrollments/__init__.py
@@ -13,7 +13,7 @@ from .models import Enrollment, Enrollments
 
 
 # pylint: disable=too-few-public-methods
-class CourseEnrollments(object):
+class CourseEnrollments:
     """
     edX student enrollments client
     """

--- a/edx_api/enrollments/init_test.py
+++ b/edx_api/enrollments/init_test.py
@@ -6,7 +6,7 @@ import os
 from unittest import TestCase
 
 try:
-    from mock import patch
+    from unittest.mock import patch
 except ImportError:
     from unittest.mock import patch
 
@@ -154,7 +154,7 @@ class EnrollmentsTest(TestCase):
         )
         mock_req.register_uri(
             'GET',
-            '{url}?cursor=next-cursor'.format(url=CourseEnrollments.enrollment_list_url),
+            f'{CourseEnrollments.enrollment_list_url}?cursor=next-cursor',
             text=json.dumps({
                 'previous': 'http://base_url/enrl/?cursor=next-cursor',
                 'results': self.enrollments_list_json[2:],

--- a/edx_api/enrollments/init_test.py
+++ b/edx_api/enrollments/init_test.py
@@ -5,10 +5,7 @@ import json
 import os
 from unittest import TestCase
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from unittest.mock import patch
+from unittest.mock import patch
 
 import requests_mock
 from urllib.parse import urljoin

--- a/edx_api/enrollments/models.py
+++ b/edx_api/enrollments/models.py
@@ -6,7 +6,7 @@ from dateutil import parser
 # pylint: disable=too-few-public-methods
 
 
-class Enrollments(object):
+class Enrollments:
     """
     The enrollments object
     """
@@ -76,7 +76,7 @@ class Enrollments(object):
         return self.enrollments.get(course_id)
 
 
-class Enrollment(object):
+class Enrollment:
     """
     Single enrollment object representation
     """
@@ -84,10 +84,7 @@ class Enrollment(object):
         self.json = json
 
     def __str__(self):
-        return "<Enrollment for user {user} in course {course}>".format(
-            user=self.user,
-            course=self.course_id
-        )
+        return f"<Enrollment for user {self.user} in course {self.course_id}>"
 
     @property
     def course_id(self):
@@ -130,7 +127,7 @@ class Enrollment(object):
         return self.mode == 'verified'
 
 
-class CourseDetails(object):
+class CourseDetails:
     """
     Course enrollment info
     """
@@ -138,7 +135,7 @@ class CourseDetails(object):
         self.json = json
 
     def __str__(self):
-        return "<Enrollment details for course {}>".format(self.course_id)
+        return f"<Enrollment details for course {self.course_id}>"
 
     @property
     def course_id(self):
@@ -207,7 +204,7 @@ class CourseDetails(object):
             yield CourseMode(course_mode_json)
 
 
-class CourseMode(object):
+class CourseMode:
     """
     Course enrollment mode
     """
@@ -215,7 +212,7 @@ class CourseMode(object):
         self.json = json
 
     def __str__(self):
-        return "<Enrollment mode {}>".format(self.slug)
+        return f"<Enrollment mode {self.slug}>"
 
     @property
     def currency(self):

--- a/edx_api/grades/__init__.py
+++ b/edx_api/grades/__init__.py
@@ -8,7 +8,7 @@ from edx_api.enrollments import CourseEnrollments
 from .models import CurrentGrade, CurrentGradesByUser, CurrentGradesByCourse
 
 
-class UserCurrentGrades(object):
+class UserCurrentGrades:
     """
     edX student certificates client
     """
@@ -37,10 +37,7 @@ class UserCurrentGrades(object):
         resp = self.requester.get(
             urljoin(
                 self.base_url,
-                '/api/grades/v1/courses/{course_key}/?username={username}'.format(
-                    username=username,
-                    course_key=course_id
-                )
+                f'/api/grades/v1/courses/{course_id}/?username={username}'
             )
         )
 
@@ -92,7 +89,7 @@ class UserCurrentGrades(object):
         resp = self.requester.get(
             urljoin(
                 self.base_url,
-                '/api/grades/v1/courses/{course_key}/'.format(course_key=course_id)
+                f'/api/grades/v1/courses/{course_id}/'
             )
         )
         resp.raise_for_status()
@@ -103,7 +100,7 @@ class UserCurrentGrades(object):
                 resp = self.requester.get(resp_json['next'])
                 resp.raise_for_status()
                 resp_json = resp.json()
-                grade_entries.extend((CurrentGrade(entry) for entry in resp_json["results"]))
+                grade_entries.extend(CurrentGrade(entry) for entry in resp_json["results"])
         else:
             grade_entries = [CurrentGrade(entry) for entry in resp_json]
 

--- a/edx_api/grades/init_test.py
+++ b/edx_api/grades/init_test.py
@@ -21,7 +21,7 @@ class GradesApiTestCase(TestCase):
     base_url = "https://edx.example.com"
 
     def setUp(self):
-        super(GradesApiTestCase, self).setUp()
+        super().setUp()
 
         with open(
             os.path.join(

--- a/edx_api/grades/models.py
+++ b/edx_api/grades/models.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 # pylint: disable=too-few-public-methods
 
 
-class CurrentGrades(object):
+class CurrentGrades:
     """
     Current Grades object representation
     """
@@ -28,7 +28,7 @@ class CurrentGradesByCourse(CurrentGrades):
         Args:
             current_grade_list (list): A list of the CurrentGrade objects
         """
-        super(CurrentGradesByCourse, self).__init__(current_grade_list)
+        super().__init__(current_grade_list)
         self.course_id = None
         self.current_grades = {}
         for current_grade in current_grade_list:
@@ -41,9 +41,7 @@ class CurrentGradesByCourse(CurrentGrades):
             self.current_grades[current_grade.username] = current_grade
 
     def __str__(self):
-        return "<Current Grades for course {course_id}>".format(
-            course_id=self.course_id
-        )
+        return f"<Current Grades for course {self.course_id}>"
 
     @property
     def all_usernames(self):
@@ -60,7 +58,7 @@ class CurrentGradesByUser(CurrentGrades):
         Args:
             current_grade_list (list): A list of the CurrentGrade objects
         """
-        super(CurrentGradesByUser, self).__init__(current_grade_list)
+        super().__init__(current_grade_list)
         self.username = None
         self.current_grades = {}
         for current_grade in current_grade_list:
@@ -69,9 +67,7 @@ class CurrentGradesByUser(CurrentGrades):
             self.current_grades[current_grade.course_id] = current_grade
 
     def __str__(self):
-        return "<Current Grades for user {username}>".format(
-            username=self.username
-        )
+        return f"<Current Grades for user {self.username}>"
 
     @property
     def all_course_ids(self):
@@ -83,7 +79,7 @@ class CurrentGradesByUser(CurrentGrades):
         return self.current_grades.get(course_id)
 
 
-class CurrentGrade(object):
+class CurrentGrade:
     """
     Single current grade object representation
     """
@@ -91,10 +87,7 @@ class CurrentGrade(object):
         self.json = json
 
     def __str__(self):
-        return "<Current Grade for user {user} in course {course}>".format(
-            user=self.username,
-            course=self.course_id
-        )
+        return f"<Current Grade for user {self.username} in course {self.course_id}>"
 
     @property
     def course_id(self):

--- a/edx_api/integration_test.py
+++ b/edx_api/integration_test.py
@@ -34,7 +34,7 @@ GeneratedCertificateFactory.create(
 """
 import os
 
-from mock import patch
+from unittest.mock import patch
 import pytest
 from requests.exceptions import HTTPError
 from requests import Response, Timeout
@@ -60,7 +60,7 @@ require_integration_settings_course_id = pytest.mark.skipif(
 )
 
 
-class FakeErroredResponse(object):
+class FakeErroredResponse:
     """Fake requests response"""
     def __init__(self, status_code):
         """
@@ -75,7 +75,7 @@ class FakeErroredResponse(object):
         raise self.error
 
 
-class FakeTimeoutResponse(object):
+class FakeTimeoutResponse:
     """Fake requests response"""
     def __init__(self, status_code):
         """

--- a/edx_api/user_info/__init__.py
+++ b/edx_api/user_info/__init__.py
@@ -4,7 +4,7 @@ from urllib.parse import urljoin
 from .models import Info
 
 
-class UserInfo(object):
+class UserInfo:
     """
     edX user info client
     """
@@ -61,7 +61,7 @@ class UserInfo(object):
         resp = self.requester.patch(
             urljoin(
                 self.base_url,
-                '/api/user/v1/accounts/{username}'.format(username=username)
+                f'/api/user/v1/accounts/{username}'
             ),
             json=request_data)
         resp.raise_for_status()

--- a/edx_api/user_info/models.py
+++ b/edx_api/user_info/models.py
@@ -1,7 +1,7 @@
 """Models for user_info client"""
 
 
-class Info(object):
+class Info:
     """
     Information about user
     """
@@ -9,9 +9,7 @@ class Info(object):
         self.json = json
 
     def __str__(self):
-        return "<User info for user {user}>".format(
-            user=self.username,
-        )
+        return f"<User info for user {self.username}>"
 
     @property
     def username(self):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = --cov edx_api --flake8 --cov-report term --cov-report html
+addopts = --cov edx_api --cov-report term --cov-report html
 norecursedirs = .git .tox .* CVS _darcs {arch} *.egg
 flake8-max-line-length = 119

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """
 Python setup file for the eds_api app.
 """
@@ -19,7 +18,7 @@ def read(filename):
     """Helper function to read bytes from file"""
     try:
         return open(os.path.join(os.path.dirname(__file__), filename)).read()
-    except IOError:
+    except OSError:
         return ''
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@ skipsdist = True
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test_requirements.txt
-commands = py.test {posargs}
+commands = pytest {posargs}
 passenv = *


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4303

### Description (What does it do?)
<!--- Describe your changes in detail -->
This PR updates the python version of edx-api-client to 3.9.x

### How can this be tested?
- Make sure your edx-platform and xpro both are running.
- Configure your xpro with openedx following the steps mentioned in [configure_open_edx.md](https://github.com/mitodl/mitxpro/blob/master/docs/configure_open_edx.md)
- Run all the management commands using the edx-api-client and validate that everything's working fine 