### PR TITLE
ci: update ubuntu runner and cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push]
 jobs:
   python-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
           python-version: "3.9"
 
       - id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/test_requirements.txt') }}


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This PR upgrades Ubuntu runner in the CI workflow to 22.04 due to the recent [20.04 deprecation](https://github.com/actions/runner-images/issues/11101). It also updates `cache` action to v4 due to [this deprecation](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down).

### How can this be tested?
To test this PR:
- Check that the workflow runs successfully on the new Ubuntu 22.04 runner
- Verify that all tests pass in the CI environment
