### PR TITLE
feat: Add course runs API management

### DIFF
--- a/edx_api/client.py
+++ b/edx_api/client.py
@@ -7,6 +7,7 @@ from .bulk_user_retirement import BulkUserRetirement
 from .ccx import CCX
 from .certificates import UserCertificates
 from .course_detail import CourseDetails, CourseModes
+from .course_runs import CourseRuns
 from .course_structure import CourseStructure
 from .enrollments import CourseEnrollments
 from .email_settings import EmailSettings
@@ -111,3 +112,8 @@ class EdxApi:
     def user_validation(self):
         """User validation API"""
         return UserValidation(self.get_requester(), self.base_url)
+
+    @property
+    def course_runs(self):
+        """Course runs management API (Works with CMS)"""
+        return CourseRuns(self.get_requester(token_type="jwt"), self.base_url)

--- a/edx_api/course_runs/__init__.py
+++ b/edx_api/course_runs/__init__.py
@@ -1,0 +1,242 @@
+"""Course Runs API"""
+
+from urllib import parse
+
+from requests.exceptions import HTTPError
+
+from .exceptions import CourseRunAPIError
+from .models import CourseRun, CourseRunList
+
+
+class CourseRuns:
+    """
+    API Client to interact with the course runs API in Open edX CMS.
+    """
+
+    course_run_url = "api/v1/course_runs/"
+    course_run_clone_url = "api/v1/course_runs/clone/"
+
+    def __init__(self, requester, base_url):
+        self._requester = requester
+        self._base_url = base_url
+
+    def _verify_and_generate_schedule(
+        self, start, end, enrollment_start, enrollment_end
+    ):
+        """
+        Verifies and builds the schedule dictionary for course run create/update payload.
+
+        Args:
+            start (datetime): The start date for the course run.
+            end (datetime): The end date for the course run.
+            enrollment_start (datetime): The enrollment start date for the course run.
+            enrollment_end (datetime): The enrollment end date for the course run.
+
+        Returns:
+            dict or None: A dictionary containing the schedule information or None.
+        """
+
+        # It is required by the Open edX that start and end dates are both present when a reschedule is requested.
+        if start or end:
+            if not (start and end):
+                raise ValueError(
+                    "Both start and end dates must be provided if one is provided."
+                )
+
+            schedule = {
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+            }
+            if enrollment_start:
+                schedule["enrollment_start"] = enrollment_start.isoformat()
+            if enrollment_end:
+                schedule["enrollment_end"] = enrollment_end.isoformat()
+            return schedule
+        return None
+
+    def clone_course_run(self, source_course_id, destination_course_id):
+        """
+        Clones a course run from source_course_id in Open edX.
+
+        Args:
+            source_course_id (str): An edx course id from which to clone the new run.
+            destination_course_id (str): A course id for the new course run to be created.
+
+        Returns:
+            Response: The response from the Open edX API.
+        Raises:
+            CourseRunError: If the request to clone the course run fails.
+        """
+
+        payload = {
+            "source_course_id": source_course_id,
+            "destination_course_id": destination_course_id,
+        }
+        resp = self._requester.post(
+            parse.urljoin(self._base_url, self.course_run_clone_url), json=payload
+        )
+        try:
+            resp.raise_for_status()
+            return resp
+        except HTTPError as ex:
+            raise CourseRunAPIError(
+                f"Failed to clone course run: {ex.response.status_code} - {ex.response.text}"
+            ) from ex
+
+    def create_course_run(
+        self,
+        org,
+        number,
+        run,
+        title,
+        pacing_type=None,
+        start=None,
+        end=None,
+        enrollment_start=None,
+        enrollment_end=None,
+    ):
+        """
+        Creates a new canonical course run in Open edX.
+
+        Args:
+            org (str): Organization for the new course run.
+            number (str): Course number for the new course run. (Without 'course-v1')
+            run (str): The run id for the new course run.
+            title (str): The title of the new course run.
+            pacing_type (str, optional): The pacing type for the new course run. Defaults to None.
+            start (datetime, optional): The start date for the new course run. Defaults to None.
+            end (datetime, optional): The end date for the new course run. Defaults to None.
+            enrollment_start (datetime, optional): The enrollment start date for the new course run. Defaults to None.
+            enrollment_end (datetime, optional): The enrollment end date for the new course run. Defaults to None.
+
+        Returns:
+            CourseRun: The course run response keys from the Open edX API.
+        Raises:
+            CourseRunError: If the request to create the course run fails.
+        """
+        payload = {
+            "org": org,
+            "number": number,
+            "run": run,
+            "title": title,
+        }
+        if pacing_type:
+            payload["pacing_type"] = pacing_type
+
+        # All the date fields should be added in a sub-dictionary named "schedule" inside the payload.
+        schedule = self._verify_and_generate_schedule(
+            start, end, enrollment_start, enrollment_end
+        )
+        if schedule:
+            payload["schedule"] = schedule
+
+        resp = self._requester.post(
+            parse.urljoin(self._base_url, self.course_run_url), json=payload
+        )
+        try:
+            resp.raise_for_status()
+            return CourseRun(resp.json())
+        except HTTPError as ex:
+            raise CourseRunAPIError(
+                f"Failed to create course run: {ex.response.status_code} - {ex.response.text}"
+            ) from ex
+
+    def update_course_run(
+        self,
+        course_id,
+        title=None,
+        pacing_type=None,
+        start=None,
+        end=None,
+        enrollment_start=None,
+        enrollment_end=None,
+    ):
+        """
+        Updates a course run in Open edX based on course_id.
+
+        Args:
+            course_id (str): Course Id for the course run to update. (Used for lookup)
+
+            The following parameters are optional and can be used to update the course run:
+
+            title (str, optional): The title of the new course run.
+            pacing_type (str, optional): The pacing type for the new course run. Defaults to None.
+            start (datetime, optional): The start date for the new course run. Defaults to None.
+            end (datetime, optional): The end date for the new course run. Defaults to None.
+            enrollment_start (datetime, optional): The enrollment start date for the new course run. Defaults to None.
+            enrollment_end (datetime, optional): The enrollment end date for the new course run. Defaults to None.
+
+        Returns:
+            CourseRun: The course run object containing the fields from the Open edX API.
+        Raises:
+            CourseRunError: If the request to update the course run fails.
+        """
+        payload = {}
+        if title:
+            payload["title"] = title
+        if pacing_type:
+            payload["pacing_type"] = pacing_type
+
+        # All the date fields should be added in a sub-dictionary named "schedule" inside the payload.
+        schedule = self._verify_and_generate_schedule(
+            start, end, enrollment_start, enrollment_end
+        )
+        if schedule:
+            payload["schedule"] = schedule
+        resp = self._requester.put(
+            parse.urljoin(self._base_url, f"{self.course_run_url}/{course_id}/"),
+            json=payload,
+        )
+        try:
+            resp.raise_for_status()
+            return CourseRun(resp.json())
+        except HTTPError as ex:
+            raise CourseRunAPIError(
+                f"Failed to update course run: {ex.response.status_code} - {ex.response.text}"
+            ) from ex
+
+    def get_course_run(self, course_id):
+        """
+        Returns a course run object in Open edX.
+
+        Args:
+            course_id (str): The course id for the course run to get.
+        Returns:
+            CourseRun: The course run object.
+        Raises:
+            CourseRunError: If the request to get the course run fails.
+        """
+        resp = self._requester.get(
+            parse.urljoin(self._base_url, f"{self.course_run_url}{course_id}/")
+        )
+        try:
+            resp.raise_for_status()
+            return CourseRun(resp.json())
+        except HTTPError as ex:
+            raise CourseRunAPIError(
+                f"Failed to get course run: {ex.response.status_code} - {ex.response.text}"
+            ) from ex
+
+    def get_course_runs_list(self, page_url=None):
+        """
+        Returns a list of course runs in Open edX.
+
+        Args:
+            page_url (str, optional): The URL for the next or previous page of course runs. Defaults to None.
+            If not provided, the first page of course runs will be fetched.
+
+        Returns:
+            list: A list of course run objects.
+        Raises:
+            CourseRunError: If the request to get the course runs list fails.
+        """
+        resp = self._requester.get(
+            page_url or parse.urljoin(self._base_url, self.course_run_url)
+        )
+        try:
+            resp.raise_for_status()
+            return CourseRunList(resp.json())
+        except HTTPError as ex:
+            raise CourseRunAPIError(
+                f"Failed to get course runs list: {ex.response.status_code} - {ex.response.text}"
+            ) from ex

--- a/edx_api/course_runs/exceptions.py
+++ b/edx_api/course_runs/exceptions.py
@@ -1,0 +1,4 @@
+class CourseRunAPIError(Exception):
+    """Base class for all course run related exceptions."""
+
+    pass

--- a/edx_api/course_runs/fixtures/course_run.json
+++ b/edx_api/course_runs/fixtures/course_run.json
@@ -1,0 +1,18 @@
+{
+    "schedule": {
+        "start": "2025-01-01T00:00:00Z",
+        "end": "2030-01-01T00:05:00Z",
+        "enrollment_start": "2025-01-02T00:00:00Z",
+        "enrollment_end": null
+    },
+    "pacing_type": "instructor_paced",
+    "team": [],
+    "id": "course-v1:ORG+NUMBER+RUN",
+    "title": "Test Course",
+    "images": {
+        "card_image": "http://studio.local.openedx.io:8001/asset-v1:ORG+NUMBER+RUN+type@asset+block@images_course_image.jpg"
+    },
+    "org": "ORG",
+    "number": "NUMBER",
+    "run": "RUN"
+}

--- a/edx_api/course_runs/fixtures/course_run_list.json
+++ b/edx_api/course_runs/fixtures/course_run_list.json
@@ -1,0 +1,58 @@
+{
+    "next": "http://studio.local.openedx.io:8001/api/v1/course_runs/?page=2",
+    "previous": null,
+    "count": 10,
+    "num_pages": 5,
+    "current_page": 1,
+    "start": 0,
+    "results": [
+       {
+            "schedule": {
+                "start": "2021-01-01T00:00:00Z",
+                "end": null,
+                "enrollment_start": null,
+                "enrollment_end": null
+            },
+            "pacing_type": "self_paced",
+            "team": [
+                {
+                    "user": "edx",
+                    "role": "instructor"
+                },
+                {
+                    "user": "edx",
+                    "role": "staff"
+                }
+            ],
+            "id": "course-v1:ORG+NUMBER+RUN",
+            "title": "Test Course",
+            "images": {
+                "card_image": "http://studio.local.openedx.io:8001/asset-v1:ORG+NUMBER+RUN+type@asset+block@images_course_image.jpg"
+            }
+        },
+        {
+            "schedule": {
+                "start": "2021-01-01T00:00:00Z",
+                "end": "2026-01-01T00:05:00Z",
+                "enrollment_start": null,
+                "enrollment_end": null
+            },
+            "pacing_type": "instructor_paced",
+            "team": [
+                {
+                    "user": "edx",
+                    "role": "instructor"
+                },
+                {
+                    "user": "edx",
+                    "role": "staff"
+                }
+            ],
+            "id": "course-v1:ORG+NUMBER+RUN1",
+            "title": "Test Course",
+            "images": {
+                "card_image": "http://studio.local.openedx.io:8001/asset-v1:ORG+NUMBER+RUN1+type@asset+block@images_course_image.jpg"
+            }
+        }
+    ]
+}

--- a/edx_api/course_runs/init_test.py
+++ b/edx_api/course_runs/init_test.py
@@ -1,0 +1,130 @@
+"""
+Tests for the content of the __init__ module in course_runs
+"""
+
+import json
+import os
+
+import pytest
+import requests_mock
+
+from unittest import TestCase
+from urllib.parse import urljoin
+
+from edx_api.client import EdxApi
+from edx_api.course_runs import CourseRuns
+
+
+class CourseRunsTest(TestCase):
+    """
+    Tests for the course runs API base function in the __init__ module
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        with open(
+            os.path.join(os.path.dirname(__file__), "fixtures/course_run.json")
+        ) as file_obj:
+            cls.course_run_json = json.loads(file_obj.read())
+
+        with open(
+            os.path.join(os.path.dirname(__file__), "fixtures/course_run_list.json")
+        ) as file_obj:
+            cls.course_run_list_json = json.loads(file_obj.read())
+        cls.course_run_clone_json = {"message": "Course cloned successfully"}
+
+        cls.course_run_responses = [
+            {"json": cls.course_run_json, "status_code": 201},
+            {"json": cls.course_run_clone_json, "status_code": 201},
+            {"json": cls.course_run_list_json, "status_code": 200},
+        ]
+
+        base_edx_url = "http://studio.local.openedx.io"
+        cls.course_run_url = urljoin(base_edx_url, CourseRuns.course_run_url)
+        cls.course_run_clone_url = urljoin(
+            base_edx_url, CourseRuns.course_run_clone_url
+        )
+        cls.client = EdxApi({"access_token": "foobar"}, base_edx_url)
+        cls.course_run_client = cls.client.course_runs
+
+    @requests_mock.mock()
+    def test_clone_course_run(self, mock_req):
+        """
+        Tests the POST request to clone a course run.
+        """
+        mock_req.post(self.course_run_clone_url, **self.course_run_responses[1])
+        response = self.course_run_client.clone_course_run(
+            source_course_id="test", destination_course_id="test1"
+        )
+        assert response.json() == self.course_run_responses[1]["json"]
+
+    @requests_mock.mock()
+    def test_create_course_run(self, mock_req):
+        """
+        Tests the POST request to create a course run.
+        """
+        mock_req.post(self.course_run_url, **self.course_run_responses[0])
+        response = self.course_run_client.create_course_run(
+            org="ORG", number="NUMBER", run="RUN", title="Test Course"
+        )
+        assert response.json == self.course_run_responses[0]["json"]
+        # Check that start and end are passed together otherwise none passed at all
+        with pytest.raises(ValueError):
+            self.course_run_client.create_course_run(
+                org="ORG",
+                number="NUMBER",
+                run="RUN",
+                title="Test Course",
+                start="2023-01-01T00:00:00Z",
+            )
+        with pytest.raises(ValueError):
+            self.course_run_client.create_course_run(
+                org="ORG",
+                number="NUMBER",
+                run="RUN",
+                title="Test Course",
+                end="2023-01-01T00:00:00Z",
+            )
+
+    @requests_mock.mock()
+    def test_update_course_run(self, mock_req):
+        """
+        Tests the PUT request to update a course run.
+        """
+        course_id = "course-v1:ORG+NUMBER+RUN"
+        url = self.course_run_url + f"{course_id}/"
+        mock_req.put(url, **self.course_run_responses[0])
+        response = self.course_run_client.update_course_run(
+            course_id=course_id, title="Updated Title", pacing_type="self_paced"
+        )
+        assert response.json == self.course_run_responses[0]["json"]
+        # Check that start and end are passed together otherwise none passed at all
+        with pytest.raises(ValueError):
+            self.course_run_client.update_course_run(
+                course_id=course_id, title="Updated Title", start="2023-01-01T00:00:00Z"
+            )
+        with pytest.raises(ValueError):
+            self.course_run_client.update_course_run(
+                course_id=course_id, title="Updated Title", end="2023-01-01T00:00:00Z"
+            )
+
+    @requests_mock.mock()
+    def test_get_course_run(self, mock_req):
+        """
+        Tests the GET request to get a single create a course run based on course ID.
+        """
+        course_id = "course-v1:ORG+NUMBER+RUN"
+        url = self.course_run_url + f"{course_id}/"
+        mock_req.get(url, **self.course_run_responses[0])
+        response = self.course_run_client.get_course_run(course_id=course_id)
+        assert response.json == self.course_run_responses[0]["json"]
+
+    @requests_mock.mock()
+    def test_get_course_run_list(self, mock_req):
+        """
+        Tests the GET request to get the list of courser runs.
+        """
+        url = self.course_run_url
+        mock_req.get(url, **self.course_run_responses[2])
+        response = self.course_run_client.get_course_runs_list()
+        assert response.json == self.course_run_responses[2]["json"]

--- a/edx_api/course_runs/models.py
+++ b/edx_api/course_runs/models.py
@@ -1,0 +1,155 @@
+"""
+Business objects for the course run API
+"""
+
+from dateutil import parser
+
+
+class CourseRun:
+    """
+    The course run object
+    """
+
+    def __init__(self, payload):
+        self.json = payload
+
+    def __str__(self):
+        return f"<Course run details for {self.course_id}>"
+
+    def __repr__(self):
+        return self.__str__()
+
+    @property
+    def schedule(self):
+        """Used to fetch the course schedule"""
+        return self.json.get("schedule")
+
+    @property
+    def start(self):
+        """Date the course run begins"""
+        try:
+            return parser.parse(self.schedule.get("start"))
+        except (AttributeError, TypeError):
+            return None
+
+    @property
+    def end(self):
+        """Date the course run ends"""
+        try:
+            return parser.parse(self.schedule.get("end"))
+        except (AttributeError, TypeError):
+            return None
+
+    @property
+    def enrollment_start(self):
+        """Date enrollment begins"""
+        try:
+            return parser.parse(self.schedule.get("enrollment_start"))
+        except (AttributeError, TypeError):
+            return None
+
+    @property
+    def enrollment_end(self):
+        """Date enrollment ends"""
+        try:
+            return parser.parse(self.schedule.get("enrollment_end"))
+        except (AttributeError, TypeError):
+            return None
+
+    @property
+    def pacing_type(self):
+        """
+        Pacing type of a course. Possible values are ("instructor_paced" or "self_paced")
+        """
+        return self.json.get("pacing_type")
+
+    @property
+    def course_id(self):
+        """
+        A unique identifier of the course; a serialized representation
+        of the opaque key identifying the course.
+        """
+        return self.json.get("id")
+
+    @property
+    def title(self):
+        """Title of the course"""
+        return self.json.get("title")
+
+    @property
+    def card_image(self):
+        """Card image of the course"""
+        return self.json.get("images").get("card_image")
+
+    @property
+    def org(self):
+        """Name of the organization that owns the course"""
+        return self.json.get("org")
+
+    @property
+    def number(self):
+        """Course number of the course"""
+        return self.json.get("number")
+
+    @property
+    def run(self):
+        """Run number of the course"""
+        return self.json.get("run")
+
+
+class CourseRunList:
+    """
+    A list of course runs
+    """
+
+    def __init__(self, payload):
+        self.json = payload
+
+    @property
+    def next(self):
+        """
+        Returns the next page of course runs list
+        """
+        return self.json.get("next", None)
+
+    @property
+    def previous(self):
+        """
+        Returns the previous page of course runs list
+        """
+        return self.json.get("previous", None)
+
+    @property
+    def count(self):
+        """
+        Returns the number of course runs
+        """
+        return self.json.get("count", 0)
+
+    @property
+    def num_pages(self):
+        """
+        Returns the number of pages of course runs list
+        """
+        return self.json.get("num_pages", 0)
+
+    @property
+    def current_page(self):
+        """
+        Returns the current page of course runs list
+        """
+        return self.json.get("current_page", 0)
+
+    @property
+    def start(self):
+        """
+        Returns the start of the pagination
+        """
+        return self.json.get("start", None)
+
+    @property
+    def results(self):
+        """
+        Returns a list of course runs
+        """
+        return [CourseRun(course_run) for course_run in self.json.get("results", [])]

--- a/edx_api/course_runs/models_test.py
+++ b/edx_api/course_runs/models_test.py
@@ -1,0 +1,133 @@
+"""Models Tests for the Course Runs API models"""
+
+import json
+import os.path
+from unittest import TestCase
+
+from dateutil import parser
+
+from .models import CourseRun, CourseRunList
+
+
+class CourseRunTests(TestCase):
+    """Tests for course run object"""
+
+    @classmethod
+    def setUpClass(cls):
+        with open(
+            os.path.join(os.path.dirname(__file__), "fixtures/course_run.json")
+        ) as file_obj:
+            cls.detail_json = json.loads(file_obj.read())
+
+        cls.detail = CourseRun(cls.detail_json)
+
+    def test_str(self):
+        """Test the __str__"""
+        assert str(self.detail) == "<Course run details for course-v1:ORG+NUMBER+RUN>"
+
+    def test_repr(self):
+        """Test the __repr__"""
+        assert (
+            self.detail.__repr__()
+            == "<Course run details for course-v1:ORG+NUMBER+RUN>"
+        )
+
+    def test_schedule(self):
+        """Test for schedule property"""
+        assert self.detail.schedule == {
+            "start": "2025-01-01T00:00:00Z",
+            "end": "2030-01-01T00:05:00Z",
+            "enrollment_start": "2025-01-02T00:00:00Z",
+            "enrollment_end": None,
+        }
+
+    def test_start(self):
+        """Test for start property"""
+        assert self.detail.start == parser.parse("2025-01-01T00:00:00Z")
+
+    def test_end(self):
+        """Test for end property"""
+        assert self.detail.end == parser.parse("2030-01-01T00:05:00Z")
+
+    def test_enrollment_start(self):
+        """Test for enrollment_start property"""
+        assert self.detail.enrollment_start == parser.parse("2025-01-02T00:00:00Z")
+
+    def test_enrollment_end(self):
+        """Test for enrollment_end property"""
+        assert self.detail.enrollment_end is None
+
+    def test_pacing_type(self):
+        """Test for pacing_type property"""
+        assert self.detail.pacing_type == "instructor_paced"
+
+    def test_course_id(self):
+        """Test for course_id property"""
+        assert self.detail.course_id == "course-v1:ORG+NUMBER+RUN"
+
+    def test_title(self):
+        """Test for title property"""
+        assert self.detail.title == "Test Course"
+
+    def test_card_image(self):
+        """Test for card_image property"""
+        assert self.detail.card_image == (
+            "http://studio.local.openedx.io:8001/asset-v1:ORG+NUMBER+RUN+type@asset+block@images_course_image.jpg"
+        )
+
+    def test_org(self):
+        """Test for org property"""
+        assert self.detail.org == "ORG"
+
+    def test_number(self):
+        """Test for number property"""
+        assert self.detail.number == "NUMBER"
+
+    def test_run(self):
+        """Test for run property"""
+        assert self.detail.run == "RUN"
+
+
+class CourseRunListTests(TestCase):
+    """Tests for course run list object"""
+
+    @classmethod
+    def setUpClass(cls):
+        with open(
+            os.path.join(os.path.dirname(__file__), "fixtures/course_run_list.json")
+        ) as file_obj:
+            cls.detail_json = json.loads(file_obj.read())
+
+        cls.list_detail = CourseRunList(cls.detail_json)
+
+    def test_next(self):
+        """Test for next property"""
+        assert self.list_detail.next == (
+            "http://studio.local.openedx.io:8001/api/v1/course_runs/?page=2"
+        )
+
+    def test_previous(self):
+        """Test for previous property"""
+        assert self.list_detail.previous == None
+
+    def test_count(self):
+        """Test for count property"""
+        assert self.list_detail.count == 10
+
+    def test_num_pages(self):
+        """Test for num_pages property"""
+        assert self.list_detail.num_pages == 5
+
+    def test_current_page(self):
+        """Test for current_page property"""
+        assert self.list_detail.current_page == 1
+
+    def test_start(self):
+        """Test for start property"""
+        assert self.list_detail.start == 0
+
+    def test_results(self):
+        """Test for results property"""
+        assert len(self.list_detail.results) == 2
+        assert isinstance(self.list_detail.results[0], CourseRun)
+        assert isinstance(self.list_detail.results[1], CourseRun)


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7262
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
The PR adds the management interface for the Course runs API in the Open edx CMS.
- The PR adds the API interfacing for `Clone`, `Create`, `Update`, `Get Object` and `Get List` functionalities
- The PR adds a new app `course_runs` in `edx_api` of the client to support all the course run related operations


### How can this be tested?

**Pre-reqs for Testing**
- Ideal: You will need to have a running instance of `MITx Online` or `MIT xPRO`
- The Course Runs API uses JWT authentication, so you will need to get a JWT token from Open edX to test this PR.

**How to get the JWT:**

To get a JWT token from Open edX, you will need to perform the following steps:

1. Create a staff user in Open edX and create an application http://local.openedx.io:8000/admin/oauth2_provider/application (It should look like)
    <img width="1174" alt="sample application" src="https://github.com/user-attachments/assets/0b5e935a-d5e8-403d-8464-b184d4826614" />
2. After that, You need to hit http://local.openedx.io:8000/oauth2/access_token with form-encoded-url params:
    ```
    grant_type:client_credentials
    client_id:<YOUR_CLIENT_ID from Above application>
    client_secret: <YOUR_CLIENT_SECRET from above application>
    token_type:jwt
    ```
3. The above API should return an access token that you can use for testing the client. (See the next steps)


**Install the client from this branch in your xPRO/MITx Online application**

1. Clone this branch in `source` directory of your application 
2. Enter the shell, `docker compose exec web bash` (or anything of the sort)
3. `pip install -e source/edx-api-client/`


**Now Actual Testing**

Once you have everything above in place, along with your tutor running:

1. Add `- "studio.local.openedx.io:host-gateway"` in the `extra-hosts` in your docker compose file (Note: This is required, otherwise you will hit max redirects error while interacting with CMS APIs)
2. Run your application and open the Docker shell from the web container. `docker compose exec web bash` -> `./manage.py shell`
3. I tested it in MIT xPRO application, but the steps should almost be similar for MITx Online too. Copy this script:
    ```python
    from django.conf import settings
    from edx_api.client import EdxApi
    from datetime import datetime, timezone

    jwt_token = "<JWT_ACCESS_TOKEN_YOU_ACQUIRED_ABOVE>"

    cms_url = "http://studio.local.openedx.io:8001"
    now = datetime.now(timezone.utc)

    edx_client = EdxApi(
        {
            "access_token": jwt_token,
        },
        cms_url,
        timeout=settings.EDX_API_CLIENT_TIMEOUT,
    )

    ```
4. With step 3, your client should be set up and ready to interact with Open edX APIs. Now you need to test each API that the client supports:
    - Test Clone: 
        ```python
        resp = edx_client.course_runs.clone_course_run(source_course_id="<AN EXISTING COURSE_ID IN EDX>", 
        destination_course_id="NEW COURSE_ID")
        ```
    - Test Create: 
        ```python
        resp = edx_client.course_runs.create_course_run(org="TEST_ORGANIZATION", 
        number="<COURSE_NUMBER_WITHOUT course-v1:>", run="R", title="Course title", pacing_type="self_paced", 
        start=now, end=now, enrollment_start=now, enrollment_end=now)
        ```
    - Test Update: 
        ```python
        resp = edx_client.course_runs.update_course_run(course_id="<EXISTING_COURSE_ID>", title="COURSE FROM API 
        (Update)", pacing_type="self_paced", start=now, end=now, enrollment_start=now, enrollment_end=now)
        ```
    - Test Get Course Run:
        ```python
        resp = edx_client.course_runs.get_course_run(course_id="<EXISTING_COURSE_ID>")
        ```
    - Test Get course run list:
        ```python
        resp = edx_client.course_runs.get_course_runs_list()
        ```


You can tweak the params for your own testing scenarios.


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
